### PR TITLE
Clean up shapegen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     exclude-paths:
-      - "/scratchstack-services/**"
+      - "scratchstack-services/**"
     schedule:
       interval: weekly
       days: ["tuesday"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
       - "scratchstack-services/**"
     schedule:
       interval: weekly
-      days: ["tuesday"]
+      day: "tuesday"
       time: "04:23"
       timezone: "America/Los_Angeles"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "scratchstack-aws-principal",
     "scratchstack-aws-signature",
     "scratchstack-bootstrap",
+    "scratchstack-cli-utils",
     "scratchstack-config",
     "scratchstack-database",
     "scratchstack-errors",
@@ -35,6 +36,9 @@ async-trait = "0.1"
 axum = "0.8"
 axum-extra = "0.12"
 aws-sigv4 = "1.4"
+aws-smithy-runtime-api = "1.12"
+aws-smithy-types = "1.4"
+aws-types = "1.3"
 base32 = "0.5"
 base64 = "0.22"
 bytes = "1.2"
@@ -75,6 +79,8 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 sqlx = "0.8"
+strum = "0.28"
+strum_macros = "0.28"
 subtle = "2.6"
 tempfile = "3.27"
 test-log = "0.2"

--- a/scratchstack-bootstrap/src/ssbs.rs
+++ b/scratchstack-bootstrap/src/ssbs.rs
@@ -126,7 +126,11 @@ enum Commands {
 async fn main() -> AnyResult<()> {
     env_logger::init();
     let vars = std::env::vars().map(|(k, v)| (k.into(), v)).collect::<Vec<(OsString, String)>>();
-    run(std::env::args_os(), vars, &mut stdout()).await
+    if let Err(e) = run(std::env::args_os(), vars, &mut stdout()).await {
+        Err(e)
+    } else {
+        Ok(())
+    }
 }
 
 /// Execute the CLI with the given arguments, environment variables, and stdout writer. This is

--- a/scratchstack-cli-utils/Cargo.toml
+++ b/scratchstack-cli-utils/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "scratchstack-cli-utils"
+description = "CLI argument handling utilities for Scratchstack services"
+
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+derive_builder.workspace = true
+regex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+chrono = { workspace = true, features = ["clock"] }
+env_logger.workspace = true
+pretty_assertions.workspace = true
+regex.workspace = true
+test-log.workspace = true

--- a/scratchstack-cli-utils/src/lib.rs
+++ b/scratchstack-cli-utils/src/lib.rs
@@ -1,0 +1,22 @@
+//! Scratchstack service API shapes.
+//!
+//! This crate contains the shapes used in the API of AWS services implemented by Scratchstack.
+//! These shapes are used in the request and response bodies of the API. This crate is intended to
+//! be used as a dependency by the service implementations and clients that need to interact with
+//! the services.
+#![warn(clippy::all)]
+#![allow(clippy::manual_range_contains)]
+#![deny(
+    missing_docs,
+    rustdoc::bare_urls,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_html_tags,
+    rustdoc::private_intra_doc_links,
+    rustdoc::unescaped_backticks
+)]
+#![cfg_attr(doc, feature(doc_cfg))]
+
+/// AWS CLI shorthand notation shapes.
+mod shorthand;
+pub use shorthand::*;

--- a/scratchstack-cli-utils/src/shorthand.rs
+++ b/scratchstack-cli-utils/src/shorthand.rs
@@ -131,168 +131,170 @@ impl Error for ParseError {}
 /// - Lists (explicit `[a,b]` or implicit csv `a,b`)
 /// - Maps (top-level `Key=Val,...` or nested `{Key=Val,...}`)
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Value {
+pub enum ShorthandValue {
     /// A single scalar value.
     Scalar(String),
 
     /// A list of values.
-    List(Vec<Value>),
+    List(Vec<ShorthandValue>),
 
     /// A map of string keys to values.
-    Map(HashMap<String, Value>),
+    Map(HashMap<String, ShorthandValue>),
 }
 
-impl<T> TryFrom<&Value> for HashMap<String, T>
+impl<T> TryFrom<&ShorthandValue> for HashMap<String, T>
 where
-    T: for<'a> TryFrom<&'a Value, Error = String>,
+    T: for<'a> TryFrom<&'a ShorthandValue, Error = String>,
 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Map(m) => m.iter().map(|(k, v)| Ok((k.clone(), T::try_from(v)?))).collect(),
+            ShorthandValue::Map(m) => m.iter().map(|(k, v)| Ok((k.clone(), T::try_from(v)?))).collect(),
             other => Err(format!("Expected a map/object, but got {other:?}")),
         }
     }
 }
 
-impl<T> TryFrom<&Value> for Option<T>
+impl<T> TryFrom<&ShorthandValue> for Option<T>
 where
-    T: for<'a> TryFrom<&'a Value, Error = String>,
+    T: for<'a> TryFrom<&'a ShorthandValue, Error = String>,
 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         T::try_from(value).map(Some)
     }
 }
 
-impl<T> TryFrom<&Value> for Vec<T>
+impl<T> TryFrom<&ShorthandValue> for Vec<T>
 where
-    T: for<'a> TryFrom<&'a Value, Error = String>,
+    T: for<'a> TryFrom<&'a ShorthandValue, Error = String>,
 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::List(l) => l.iter().map(|v| T::try_from(v)).collect(),
+            ShorthandValue::List(l) => l.iter().map(|v| T::try_from(v)).collect(),
             other => Err(format!("Expected a list/array, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for DateTime<Utc> {
+impl TryFrom<&ShorthandValue> for DateTime<Utc> {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => s.parse::<DateTime<Utc>>().map_err(|e| format!("Failed to parse DateTime: {}", e)),
+            ShorthandValue::Scalar(s) => {
+                s.parse::<DateTime<Utc>>().map_err(|e| format!("Failed to parse DateTime: {}", e))
+            }
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for String {
+impl TryFrom<&ShorthandValue> for String {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => Ok(s.clone()),
+            ShorthandValue::Scalar(s) => Ok(s.clone()),
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for bool {
+impl TryFrom<&ShorthandValue> for bool {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => s.parse::<bool>().map_err(|e| format!("Failed to parse bool: {}", e)),
+            ShorthandValue::Scalar(s) => s.parse::<bool>().map_err(|e| format!("Failed to parse bool: {}", e)),
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for i8 {
+impl TryFrom<&ShorthandValue> for i8 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => s.parse::<i8>().map_err(|e| format!("Failed to parse i8: {}", e)),
+            ShorthandValue::Scalar(s) => s.parse::<i8>().map_err(|e| format!("Failed to parse i8: {}", e)),
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for i16 {
+impl TryFrom<&ShorthandValue> for i16 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => s.parse::<i16>().map_err(|e| format!("Failed to parse i16: {}", e)),
+            ShorthandValue::Scalar(s) => s.parse::<i16>().map_err(|e| format!("Failed to parse i16: {}", e)),
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for i32 {
+impl TryFrom<&ShorthandValue> for i32 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => s.parse::<i32>().map_err(|e| format!("Failed to parse i32: {}", e)),
+            ShorthandValue::Scalar(s) => s.parse::<i32>().map_err(|e| format!("Failed to parse i32: {}", e)),
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl TryFrom<&Value> for i64 {
+impl TryFrom<&ShorthandValue> for i64 {
     type Error = String;
 
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
+    fn try_from(value: &ShorthandValue) -> Result<Self, Self::Error> {
         match value {
-            Value::Scalar(s) => s.parse::<i64>().map_err(|e| format!("Failed to parse i64: {}", e)),
+            ShorthandValue::Scalar(s) => s.parse::<i64>().map_err(|e| format!("Failed to parse i64: {}", e)),
             other => Err(format!("Expected a scalar value, but got {other:?}")),
         }
     }
 }
 
-impl Value {
+impl ShorthandValue {
     /// Convenience: get a scalar string reference.
     pub fn as_str(&self) -> Option<&str> {
         match self {
-            Value::Scalar(s) => Some(s),
+            ShorthandValue::Scalar(s) => Some(s),
             _ => None,
         }
     }
 
     /// Convenience: get a list reference.
-    pub fn as_list(&self) -> Option<&[Value]> {
+    pub fn as_list(&self) -> Option<&[ShorthandValue]> {
         match self {
-            Value::List(v) => Some(v),
+            ShorthandValue::List(v) => Some(v),
             _ => None,
         }
     }
 
     /// Convenience: get a map reference.
-    pub fn as_map(&self) -> Option<&HashMap<String, Value>> {
+    pub fn as_map(&self) -> Option<&HashMap<String, ShorthandValue>> {
         match self {
-            Value::Map(v) => Some(v),
+            ShorthandValue::Map(v) => Some(v),
             _ => None,
         }
     }
 
     /// Look up a key in a Map value.
-    pub fn get(&self, key: &str) -> Option<&Value> {
+    pub fn get(&self, key: &str) -> Option<&ShorthandValue> {
         match self {
-            Value::Map(entries) => entries.get(key),
+            ShorthandValue::Map(entries) => entries.get(key),
             _ => None,
         }
     }
 }
 
-impl FromStr for Value {
+impl FromStr for ShorthandValue {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -353,10 +355,10 @@ impl<'a> ShorthandParser<'a> {
     /// Parse the input and return the top-level map.
     ///
     /// ```
-    /// use scratchstack_shapes_iam::shorthand::ShorthandParser;
+    /// use scratchstack_cli_utils::ShorthandParser;
     /// let result = ShorthandParser::new("Key=Value,Foo=Bar").parse().unwrap();
     /// ```
-    pub fn parse(mut self) -> Result<Value, ParseError> {
+    pub fn parse(mut self) -> Result<ShorthandValue, ParseError> {
         let result = self.parameter()?;
         Ok(result)
     }
@@ -427,7 +429,7 @@ impl<'a> ShorthandParser<'a> {
     // -- Grammar productions ------------------------------------------------
 
     /// `parameter = keyval *("," keyval)`
-    fn parameter(&mut self) -> Result<Value, ParseError> {
+    fn parameter(&mut self) -> Result<ShorthandValue, ParseError> {
         let mut entries = HashMap::new();
         let (key, val) = self.keyval()?;
         entries.insert(key, val);
@@ -450,11 +452,11 @@ impl<'a> ShorthandParser<'a> {
             last_index = self.index;
         }
 
-        Ok(Value::Map(entries))
+        Ok(ShorthandValue::Map(entries))
     }
 
     /// `keyval = key ("=" / "@=") [values]`
-    fn keyval(&mut self) -> Result<(String, Value), ParseError> {
+    fn keyval(&mut self) -> Result<(String, ShorthandValue), ParseError> {
         let key = self.key()?;
         let mut is_paramfile = false;
 
@@ -489,9 +491,9 @@ impl<'a> ShorthandParser<'a> {
     }
 
     /// `values = csv-list / explicit-list / hash-literal`
-    fn values(&mut self, _is_paramfile: bool) -> Result<Value, ParseError> {
+    fn values(&mut self, _is_paramfile: bool) -> Result<ShorthandValue, ParseError> {
         if self.at_eof() {
-            return Ok(Value::Scalar(String::new()));
+            return Ok(ShorthandValue::Scalar(String::new()));
         }
         match self.current() {
             Some('[') => self.explicit_list(),
@@ -508,12 +510,12 @@ impl<'a> ShorthandParser<'a> {
     /// foo=a,b,c=d   -> Scalar("a")  (b,c=d backtracks — the , after a is
     ///                                part of the top-level parameter separator)
     /// ```
-    fn csv_value(&mut self) -> Result<Value, ParseError> {
+    fn csv_value(&mut self) -> Result<ShorthandValue, ParseError> {
         let first = self.first_value()?;
         self.consume_whitespace();
 
         if self.at_eof() || self.current_byte() != Some(b',') {
-            return Ok(Value::Scalar(first));
+            return Ok(ShorthandValue::Scalar(first));
         }
 
         // Speculatively consume the comma.
@@ -555,14 +557,14 @@ impl<'a> ShorthandParser<'a> {
 
         if csv_list.len() == 1 {
             // foo=bar,  then backtracked: return the scalar.
-            Ok(Value::Scalar(first))
+            Ok(ShorthandValue::Scalar(first))
         } else {
-            Ok(Value::List(csv_list.into_iter().map(Value::Scalar).collect()))
+            Ok(ShorthandValue::List(csv_list.into_iter().map(ShorthandValue::Scalar).collect()))
         }
     }
 
     /// `explicit-list = "[" [value *("," value)] "]"`
-    fn explicit_list(&mut self) -> Result<Value, ParseError> {
+    fn explicit_list(&mut self) -> Result<ShorthandValue, ParseError> {
         self.expect('[', true)?;
         let mut values = Vec::new();
         while self.current() != Some(']') {
@@ -575,23 +577,23 @@ impl<'a> ShorthandParser<'a> {
             }
         }
         self.expect(']', false)?;
-        Ok(Value::List(values))
+        Ok(ShorthandValue::List(values))
     }
 
     /// Values inside `[...]` — same as top-level values but no csv ambiguity.
-    fn explicit_values(&mut self) -> Result<Value, ParseError> {
+    fn explicit_values(&mut self) -> Result<ShorthandValue, ParseError> {
         match self.current() {
             Some('[') => self.explicit_list(),
             Some('{') => self.hash_literal(),
             _ => {
                 let v = self.first_value()?;
-                Ok(Value::Scalar(v))
+                Ok(ShorthandValue::Scalar(v))
             }
         }
     }
 
     /// `hash-literal = "{" keyval *("," keyval) "}"`
-    fn hash_literal(&mut self) -> Result<Value, ParseError> {
+    fn hash_literal(&mut self) -> Result<ShorthandValue, ParseError> {
         self.expect('{', true)?;
         let mut entries = HashMap::new();
         while self.current() != Some('}') {
@@ -617,7 +619,7 @@ impl<'a> ShorthandParser<'a> {
             entries.insert(key, val);
         }
         self.expect('}', false)?;
-        Ok(Value::Map(entries))
+        Ok(ShorthandValue::Map(entries))
     }
 
     // -- Value terminals ----------------------------------------------------
@@ -768,13 +770,13 @@ impl<'a> ShorthandParser<'a> {
 /// Parse a shorthand expression, returning the top-level value.
 ///
 /// ```
-/// use scratchstack_shapes_iam::shorthand::{parse, Value};
+/// use scratchstack_cli_utils::{parse_shorthand, ShorthandValue};
 ///
-/// let val = parse("Key=Hello,Foo=Bar").unwrap();
+/// let val = parse_shorthand("Key=Hello,Foo=Bar").unwrap();
 /// assert_eq!(val.get("Key").unwrap().as_str(), Some("Hello"));
 /// assert_eq!(val.get("Foo").unwrap().as_str(), Some("Bar"));
 /// ```
-pub fn parse(input: &str) -> Result<Value, ParseError> {
+pub fn parse_shorthand(input: &str) -> Result<ShorthandValue, ParseError> {
     ShorthandParser::new(input).parse()
 }
 
@@ -787,54 +789,54 @@ mod tests {
     use super::*;
 
     // Helpers for building expected values concisely.
-    fn s(v: &str) -> Value {
-        Value::Scalar(v.to_string())
+    fn s(v: &str) -> ShorthandValue {
+        ShorthandValue::Scalar(v.to_string())
     }
-    fn list(vs: Vec<Value>) -> Value {
-        Value::List(vs)
+    fn list(vs: Vec<ShorthandValue>) -> ShorthandValue {
+        ShorthandValue::List(vs)
     }
-    fn map(pairs: Vec<(&str, Value)>) -> Value {
-        Value::Map(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+    fn map(pairs: Vec<(&str, ShorthandValue)>) -> ShorthandValue {
+        ShorthandValue::Map(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
     }
 
     // -- Basic key=value pairs ----------------------------------------------
 
     #[test]
     fn single_keyval() {
-        assert_eq!(parse("foo=bar").unwrap(), map(vec![("foo", s("bar"))]));
+        assert_eq!(parse_shorthand("foo=bar").unwrap(), map(vec![("foo", s("bar"))]));
     }
 
     #[test]
     fn multiple_keyvals() {
-        assert_eq!(parse("foo=bar,baz=qux").unwrap(), map(vec![("foo", s("bar")), ("baz", s("qux"))]));
+        assert_eq!(parse_shorthand("foo=bar,baz=qux").unwrap(), map(vec![("foo", s("bar")), ("baz", s("qux"))]));
     }
 
     #[test]
     fn three_keyvals() {
-        assert_eq!(parse("a=b,c=d,e=f").unwrap(), map(vec![("a", s("b")), ("c", s("d")), ("e", s("f"))]));
+        assert_eq!(parse_shorthand("a=b,c=d,e=f").unwrap(), map(vec![("a", s("b")), ("c", s("d")), ("e", s("f"))]));
     }
 
     #[test]
     fn empty_value() {
-        assert_eq!(parse("foo=").unwrap(), map(vec![("foo", s(""))]));
+        assert_eq!(parse_shorthand("foo=").unwrap(), map(vec![("foo", s(""))]));
     }
 
     // -- Quoting ------------------------------------------------------------
 
     #[test]
     fn double_quoted_value() {
-        assert_eq!(parse("foo=\"bar\"").unwrap(), map(vec![("foo", s("bar"))]));
+        assert_eq!(parse_shorthand("foo=\"bar\"").unwrap(), map(vec![("foo", s("bar"))]));
     }
 
     #[test]
     fn single_quoted_value() {
-        assert_eq!(parse("foo='bar'").unwrap(), map(vec![("foo", s("bar"))]));
+        assert_eq!(parse_shorthand("foo='bar'").unwrap(), map(vec![("foo", s("bar"))]));
     }
 
     #[test]
     fn quoted_value_with_comma() {
         assert_eq!(
-            parse("Key=\"hello, world\",Value=test").unwrap(),
+            parse_shorthand("Key=\"hello, world\",Value=test").unwrap(),
             map(vec![("Key", s("hello, world")), ("Value", s("test"))])
         );
     }
@@ -842,19 +844,19 @@ mod tests {
     #[test]
     fn quoted_value_with_spaces() {
         assert_eq!(
-            parse("Key=\"Hello\",Value=\"World 1 2 3\"").unwrap(),
+            parse_shorthand("Key=\"Hello\",Value=\"World 1 2 3\"").unwrap(),
             map(vec![("Key", s("Hello")), ("Value", s("World 1 2 3"))])
         );
     }
 
     #[test]
     fn escaped_quote_inside_double_quoted() {
-        assert_eq!(parse(r#"foo="say \"hi\"""#).unwrap(), map(vec![("foo", s("say \"hi\""))]));
+        assert_eq!(parse_shorthand(r#"foo="say \"hi\"""#).unwrap(), map(vec![("foo", s("say \"hi\""))]));
     }
 
     #[test]
     fn escaped_quote_inside_single_quoted() {
-        assert_eq!(parse(r"foo='it\'s'").unwrap(), map(vec![("foo", s("it's"))]));
+        assert_eq!(parse_shorthand(r"foo='it\'s'").unwrap(), map(vec![("foo", s("it's"))]));
     }
 
     // -- CSV values (implicit lists) ----------------------------------------
@@ -872,7 +874,7 @@ mod tests {
         //   foo="a", c="d"  (b is part of the backtrack)
         //
         // But foo=a,b (no more keyvals) -> foo=["a","b"]
-        let result = parse("foo=a,b").unwrap();
+        let result = parse_shorthand("foo=a,b").unwrap();
         // The parser sees a,b — first value "a", comma, tries second value "b".
         // "b" is valid but then there's no "=" after, so at top level this is
         // actually foo=["a","b"] since it's only two values with no = in sight.
@@ -883,19 +885,22 @@ mod tests {
 
     #[test]
     fn explicit_list_simple() {
-        assert_eq!(parse("foo=[a,b,c]").unwrap(), map(vec![("foo", list(vec![s("a"), s("b"), s("c")]))]));
+        assert_eq!(parse_shorthand("foo=[a,b,c]").unwrap(), map(vec![("foo", list(vec![s("a"), s("b"), s("c")]))]));
     }
 
     #[test]
     fn explicit_list_with_quotes() {
-        assert_eq!(parse("foo=[\"a b\",c]").unwrap(), map(vec![("foo", list(vec![s("a b"), s("c")]))]));
+        assert_eq!(parse_shorthand("foo=[\"a b\",c]").unwrap(), map(vec![("foo", list(vec![s("a b"), s("c")]))]));
     }
 
     // -- Hash literals ------------------------------------------------------
 
     #[test]
     fn hash_literal() {
-        assert_eq!(parse("foo={a=1,b=2}").unwrap(), map(vec![("foo", map(vec![("a", s("1")), ("b", s("2"))]))]));
+        assert_eq!(
+            parse_shorthand("foo={a=1,b=2}").unwrap(),
+            map(vec![("foo", map(vec![("a", s("1")), ("b", s("2"))]))])
+        );
     }
 
     // -- Nested structures --------------------------------------------------
@@ -903,7 +908,7 @@ mod tests {
     #[test]
     fn nested_list_in_hash() {
         assert_eq!(
-            parse("foo={a=[1,2],b=3}").unwrap(),
+            parse_shorthand("foo={a=[1,2],b=3}").unwrap(),
             map(vec![("foo", map(vec![("a", list(vec![s("1"), s("2")])), ("b", s("3")),]))])
         );
     }
@@ -912,14 +917,14 @@ mod tests {
 
     #[test]
     fn escaped_comma_in_value() {
-        assert_eq!(parse("foo=a\\,b").unwrap(), map(vec![("foo", s("a,b"))]));
+        assert_eq!(parse_shorthand("foo=a\\,b").unwrap(), map(vec![("foo", s("a,b"))]));
     }
 
     // -- Duplicate key detection --------------------------------------------
 
     #[test]
     fn duplicate_key_error() {
-        let err = parse("Key=a,Key=b").unwrap_err();
+        let err = parse_shorthand("Key=a,Key=b").unwrap_err();
         assert!(matches!(err, ParseError::DuplicateKey { .. }));
     }
 
@@ -927,7 +932,7 @@ mod tests {
 
     #[test]
     fn key_with_dots_and_colons() {
-        assert_eq!(parse("aws:tag/Name=hello").unwrap(), map(vec![("aws:tag/Name", s("hello"))]));
+        assert_eq!(parse_shorthand("aws:tag/Name=hello").unwrap(), map(vec![("aws:tag/Name", s("hello"))]));
     }
 
     // -- Paramfile syntax (@=) ---------------------------------------------
@@ -935,7 +940,7 @@ mod tests {
     #[test]
     fn paramfile_marker_parsed() {
         // We parse @= but don't resolve files — just pass through the value.
-        assert_eq!(parse("data@=file://config.json").unwrap(), map(vec![("data", s("file://config.json"))]));
+        assert_eq!(parse_shorthand("data@=file://config.json").unwrap(), map(vec![("data", s("file://config.json"))]));
     }
 
     // -- Value with equals sign in it ---------------------------------------
@@ -943,6 +948,6 @@ mod tests {
     #[test]
     fn value_containing_equals() {
         // First value can contain `=`.
-        assert_eq!(parse("foo=a=b").unwrap(), map(vec![("foo", s("a=b"))]));
+        assert_eq!(parse_shorthand("foo=a=b").unwrap(), map(vec![("foo", s("a=b"))]));
     }
 }

--- a/scratchstack-database/Cargo.toml
+++ b/scratchstack-database/Cargo.toml
@@ -35,6 +35,7 @@ regex.workspace = true
 scratchstack-arn = { path = "../scratchstack-arn", optional = true }
 scratchstack-aws-principal.path = "../scratchstack-aws-principal"
 scratchstack-aws-signature = { path = "../scratchstack-aws-signature", features = ["unstable"] }
+scratchstack-cli-utils.path = "../scratchstack-cli-utils"
 scratchstack-errors.path = "../scratchstack-errors"
 scratchstack-pagination.path = "../scratchstack-pagination"
 scratchstack-shapes-iam = { path = "../scratchstack-shapes-iam", optional = true }

--- a/scratchstack-database/src/ops/iam/account.rs
+++ b/scratchstack-database/src/ops/iam/account.rs
@@ -10,7 +10,7 @@ use {
     base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD},
     indoc::indoc,
     rand::random_range,
-    scratchstack_shapes_iam::shorthand::Value as ShorthandValue,
+    scratchstack_cli_utils::ShorthandValue,
     serde::{Deserialize, Serialize},
     sqlx::{
         Acquire as _, Row as _,

--- a/scratchstack-database/src/ops/iam/user.rs
+++ b/scratchstack-database/src/ops/iam/user.rs
@@ -20,7 +20,8 @@ use {
     scratchstack_pagination::{OperationPaginator, ScratchstackOperationMetadata, ScratchstackServiceMetadata},
     scratchstack_shapes_iam::{
         AttachedPermissionsBoundary, CreateUserInternalRequest, CreateUserResponse, ListUsersInternalRequest,
-        ListUsersResponse, PermissionsBoundaryAttachmentType, Tag, UpdateUserInternalRequest, User,
+        ListUsersResponse, NoSuchEntityException, PermissionsBoundaryAttachmentType, Tag, UpdateUserInternalRequest,
+        User,
     },
     serde::{Deserialize, Serialize},
     sqlx::{FromRow, QueryBuilder, Row as _, postgres::PgTransaction, query},
@@ -371,7 +372,10 @@ pub async fn update_user(
     .await?;
 
     if result.rows_affected() == 0 {
-        Err(anyhow!("The user with name {user_name} cannot be found."))
+        let e = NoSuchEntityException::builder()
+            .message(format!("The user with name {user_name} cannot be found."))
+            .build()?;
+        Err(e.into())
     } else {
         Ok(())
     }

--- a/scratchstack-shapegen/Cargo.toml
+++ b/scratchstack-shapegen/Cargo.toml
@@ -10,6 +10,10 @@ edition.workspace = true
 version.workspace = true
 
 [dependencies]
+indoc.workspace = true
+log.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 typed-arena.workspace = true

--- a/scratchstack-shapegen/src/enum.rs
+++ b/scratchstack-shapegen/src/enum.rs
@@ -1,9 +1,8 @@
 use {
-    super::{Member, Typed, to_pascal_case},
+    crate::{Member, ShapeBase, ShapeInfo, StrExt, forward_shape_info},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::{
-        collections::HashMap,
+        collections::BTreeMap,
         io::{Result as IoResult, Write},
     },
 };
@@ -12,17 +11,13 @@ use {
 /// listed in the enum is a member that implicitly targets the unit type.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Enum {
-    /// The name of this enum in the Smithy model.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub smithy_typename: Option<String>,
+    /// Basic shape information for the enum.
+    #[serde(flatten)]
+    pub base: ShapeBase,
 
-    /// The Rust name of this enum.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub rust_typename: Option<String>,
+    /// The members of the enum. Each member implicitly targets the unit type.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub members: BTreeMap<String, Member>,
 
     /// Whether this enum is reachable from an API input shape. This is used to determine
     /// whether to generate Clap parsers for this enum.
@@ -30,14 +25,26 @@ pub struct Enum {
     /// This is resolved during a call to `SmithyModel::resolve`.
     #[serde(skip, default)]
     pub reachable_from_input: bool,
+}
 
-    /// The members of the enum. Each member implicitly targets the unit type.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub members: HashMap<String, Member>,
+impl ShapeInfo for Enum {
+    forward_shape_info!(Enum, base);
 
-    /// Traits to apply to the type.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
+    fn clap_parser(&self) -> Option<String> {
+        let rust_typename = self.rust_typename();
+        Some(format!("{rust_typename}::from_str"))
+    }
+
+    fn mark_reachable_from_input(&mut self) {
+        self.reachable_from_input = true;
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        self.write_rust_decl(output)?;
+        self.write_shorthand_parser(output)?;
+        self.write_clap_parser(output)?;
+        Ok(())
+    }
 }
 
 impl Enum {
@@ -45,21 +52,17 @@ impl Enum {
     fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
         let rust_typename = self.rust_typename();
 
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
+        self.base.traits.write_docs(output, "")?;
 
-        writeln!(output, "#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]")?;
-
+        // Attributes for the enum.
+        writeln!(output, "#[derive(::serde::Deserialize, ::serde::Serialize)]")?;
+        writeln!(
+            output,
+            "#[derive(::std::clone::Clone, ::std::cmp::Eq, ::std::cmp::PartialEq, ::std::fmt::Debug, ::std::hash::Hash, ::std::marker::Copy)]"
+        )?;
         if self.reachable_from_input {
             writeln!(output, "#[cfg_attr(feature = \"clap\", derive(::clap::ValueEnum))]")?;
         }
-
         writeln!(output, "#[non_exhaustive]")?;
         writeln!(output, "pub enum {rust_typename} {{")?;
 
@@ -71,16 +74,9 @@ impl Enum {
                 is_first = false;
             }
 
-            let docs = member.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-            if let Some(docs) = docs {
-                for line in docs.lines() {
-                    writeln!(output, "    /// {}", line.trim())?;
-                }
-            } else {
-                writeln!(output, "    #[allow(missing_docs)]")?;
-            }
+            member.traits.write_docs(output, "    ")?;
 
-            let rust_member_name = to_pascal_case(member_name);
+            let rust_member_name = member_name.to_pascal_case();
             if &rust_member_name != member_name {
                 writeln!(output, "    #[serde(rename = \"{member_name}\")]")?;
             }
@@ -92,29 +88,34 @@ impl Enum {
         Ok(())
     }
 
+    /// Write a rust implemenation of `TryFrom<&ShorthandValue>` for this structure.
+    ///
+    /// This allows the structure to be created from a `ShorthandValue`, used to parse parameters
+    /// provided on the CLI in a shorthand format, e.g. `--tag Key=key,Value=value` instead of the
+    /// more verbose JSON syntax `--tag [{"Key":"key","Value":"value"}]`.
     fn write_shorthand_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("Enum shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
+        let simple_name = self.simple_name();
         let rust_typename = self.rust_typename();
 
         writeln!(output, "#[cfg(feature = \"clap\")]")?;
-        writeln!(output, "impl TryFrom<&crate::shorthand::Value> for {rust_typename} {{")?;
+        writeln!(output, "impl TryFrom<&::scratchstack_cli_utils::ShorthandValue> for {rust_typename} {{")?;
         writeln!(output, "    type Error = String;")?;
-        writeln!(output, "    fn try_from(value: &crate::shorthand::Value) -> Result<Self, Self::Error> {{")?;
-        writeln!(output, "        if let crate::shorthand::Value::Scalar(s) = value {{")?;
+        writeln!(
+            output,
+            "    fn try_from(value: &::scratchstack_cli_utils::ShorthandValue) -> Result<Self, Self::Error> {{"
+        )?;
+        writeln!(output, "        if let ::scratchstack_cli_utils::ShorthandValue::Scalar(s) = value {{")?;
         writeln!(output, "            match s.as_str() {{")?;
         for (member_name, _) in self.members.iter() {
-            let rust_member_name = to_pascal_case(member_name);
+            let rust_member_name = member_name.to_pascal_case();
             writeln!(output, "                \"{member_name}\" => Ok(Self::{rust_member_name}),")?;
         }
-        writeln!(output, "                _ => Err(format!(\"Invalid value '{{s}}' for enum {simple_typename}\")),")?;
+        writeln!(output, "                _ => Err(format!(\"Invalid value '{{s}}' for enum {simple_name}\")),")?;
         writeln!(output, "            }}")?;
         writeln!(output, "        }} else {{")?;
         writeln!(
             output,
-            "            Err(format!(\"Expected a string value to parse {simple_typename}, but got '{{value:?}}'\"))"
+            "            Err(format!(\"Expected a string value to parse {simple_name}, but got '{{value:?}}'\"))"
         )?;
         writeln!(output, "        }}")?;
         writeln!(output, "    }}")?;
@@ -124,10 +125,7 @@ impl Enum {
     }
 
     fn write_clap_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("Enum shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
+        let simple_typename = self.simple_name();
         let rust_typename = self.rust_typename();
 
         writeln!(output, "#[cfg(feature = \"clap\")]")?;
@@ -136,7 +134,7 @@ impl Enum {
         writeln!(output, "    fn from_str(s: &str) -> Result<Self, Self::Err> {{")?;
         writeln!(output, "        match s {{")?;
         for (member_name, _) in self.members.iter() {
-            let rust_member_name = to_pascal_case(member_name);
+            let rust_member_name = member_name.to_pascal_case();
             writeln!(output, "            \"{member_name}\" => Ok(Self::{rust_member_name}),")?;
         }
         writeln!(output, "            _ => Err(format!(\"Invalid value '{{s}}' for enum {simple_typename}\")),")?;
@@ -145,27 +143,5 @@ impl Enum {
         writeln!(output, "}}")?;
         writeln!(output)?;
         Ok(())
-    }
-}
-
-impl Typed for Enum {
-    fn rust_typename(&self) -> String {
-        self.rust_typename.clone().expect("Enum type should be resolved before generating Rust code")
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl(output)?;
-        self.write_shorthand_parser(output)?;
-        self.write_clap_parser(output)?;
-        Ok(())
-    }
-
-    fn get_clap_parser(&self) -> String {
-        let rust_typename = self.rust_typename();
-        format!("{rust_typename}::from_str")
-    }
-
-    fn mark_reachable_from_input(&mut self) {
-        self.reachable_from_input = true;
     }
 }

--- a/scratchstack-shapegen/src/int_enum.rs
+++ b/scratchstack-shapegen/src/int_enum.rs
@@ -1,9 +1,8 @@
 use {
-    super::{Member, Typed},
+    crate::{Member, ShapeBase, ShapeInfo, StrExt, forward_shape_info},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::{
-        collections::HashMap,
+        collections::BTreeMap,
         io::{Result as IoResult, Write},
     },
 };
@@ -12,74 +11,50 @@ use {
 /// of intEnum MUST be marked with the enumValue trait set to a unique integer value.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IntEnum {
-    /// The name of this enum in the Smithy model.
-    #[serde(skip, default)]
-    pub smithy_typename: Option<String>,
-
-    /// The Rust name of this enum.
-    #[serde(skip, default)]
-    pub rust_typename: Option<String>,
+    /// Basic shape information for the enum.
+    #[serde(flatten)]
+    pub base: ShapeBase,
 
     /// The members of the intEnum. Each member MUST be marked with the enumValue trait set to a
     /// unique integer value.
-    pub members: HashMap<String, Member>,
-
-    /// Traits to apply to the type.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
+    pub members: BTreeMap<String, Member>,
 }
 
-impl Typed for IntEnum {
-    fn rust_typename(&self) -> String {
-        self.rust_typename.clone().expect("IntEnum type should be resolved before generating Rust code")
+impl ShapeInfo for IntEnum {
+    forward_shape_info!(IntEnum, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        let typename = self.rust_typename();
+        Some(format!("{typename}::parse"))
     }
 
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
         let rust_type = self.rust_typename();
 
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
+        self.base.traits.write_docs(output, "")?;
 
+        writeln!(output, "#[derive(::serde::Deserialize, ::serde::Serialize,)]")?;
         writeln!(
             output,
-            "#[derive(::serde::Deserialize, ::serde::Serialize, ::std::clone::Clone, ::std::cmp::Eq, ::std::cmp::PartialEq, ::std::fmt::Debug, ::std::hash::Hash, ::std::marker::Copy)]"
+            "#[derive(::std::clone::Clone, ::std::cmp::Eq, ::std::cmp::PartialEq, ::std::fmt::Debug, ::std::hash::Hash, ::std::marker::Copy)]"
         )?;
         writeln!(output, "#[cfg_attr(feature = \"clap\", derive(::clap::ValueEnum))]")?;
         writeln!(output, "#[non_exhaustive]")?;
         writeln!(output, "pub enum {rust_type} {{")?;
 
         for (member_name, member) in self.members.iter() {
-            let docs = member.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-            if let Some(docs) = docs {
-                for line in docs.lines() {
-                    writeln!(output, "    /// {}", line.trim())?;
-                }
-            } else {
-                writeln!(output, "    #[allow(missing_docs)]")?;
-            }
+            member.traits.write_docs(output, "    ")?;
+            let rust_member_name = member_name.to_pascal_case();
+            let value = member.traits.enum_value_as_i64().expect("enumValue trait must be an integer");
 
-            let evalue =
-                member.traits.get("smithy.api#enumValue").expect("intEnum members must have an enumValue trait");
-            let value = evalue.as_i64().expect("enumValue trait must be an integer");
-            writeln!(output, "    #[serde(rename = \"{member_name}\")]")?;
-            writeln!(output, "    {member_name} = {value},")?;
+            if &rust_member_name != member_name {
+                writeln!(output, "    #[serde(rename = \"{member_name}\")]")?;
+            }
+            writeln!(output, "    {rust_member_name} = {value},")?;
         }
 
         writeln!(output, "}}")?;
 
         Ok(())
     }
-
-    fn get_clap_parser(&self) -> String {
-        let typename = self.rust_typename();
-        format!("{typename}::parse")
-    }
-
-    fn mark_reachable_from_input(&mut self) {}
 }

--- a/scratchstack-shapegen/src/length_constraint.rs
+++ b/scratchstack-shapegen/src/length_constraint.rs
@@ -1,0 +1,19 @@
+/// A length constraint associated with a shape.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct LengthConstraint {
+    /// The lower bound, if any.
+    pub min: Option<usize>,
+
+    /// The upper bound, if any.
+    pub max: Option<usize>,
+}
+
+impl LengthConstraint {
+    /// Creates a new `LengthConstraint` with the given min and max.
+    pub fn new(min: Option<usize>, max: Option<usize>) -> Self {
+        Self {
+            min,
+            max,
+        }
+    }
+}

--- a/scratchstack-shapegen/src/lib.rs
+++ b/scratchstack-shapegen/src/lib.rs
@@ -1,137 +1,108 @@
+//! Rust code generation library for Smithy shape models.
 use std::io::{Result as IoResult, Write};
 
+/// Primitive Smithy types.
 pub mod primitive;
 
 mod r#enum;
 mod int_enum;
+mod length_constraint;
 mod list;
 mod map;
 mod member;
 mod operation;
+mod range_constraint;
 mod resource;
 mod service;
 mod shape;
+mod shape_base;
 mod shape_ref;
 mod smithy_model;
+mod str_ext;
 mod structure;
+mod trait_id;
+mod trait_map;
 mod r#union;
 
 #[allow(unused_imports)]
 pub use {
-    r#enum::*, int_enum::*, list::*, map::*, member::*, operation::*, resource::*, service::*, shape::*, shape_ref::*,
-    smithy_model::*, structure::*, r#union::*,
+    r#enum::*, int_enum::*, length_constraint::*, list::*, map::*, member::*, operation::*, range_constraint::*,
+    resource::*, service::*, shape::*, shape_base::*, shape_ref::*, smithy_model::*, str_ext::*, structure::*,
+    trait_id::*, trait_map::*, r#union::*,
 };
 
-/// Rust keywords that cannot be used as identifiers. These are used to determine when to use raw
-/// identifiers in the generated code.
-const RUST_IDENTS: &[&str] = &[
-    "abstract", "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern",
-    "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
-    "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where", "while",
-];
+/// Trait for all named shapes.
+pub trait ShapeInfo {
+    /// Resolve this shape, setting the Smithy name internally.
+    fn resolve(&mut self, smithy_name: &str, model: &SmithyModel);
 
-/// Convert an identifier to snake case. This is used to convert Smithy member names to Rust field names.
-pub fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut prev_char_was_uppercase = false;
+    /// Returns the Smithy name of this shape.
+    fn smithy_name(&self) -> String;
 
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 && !prev_char_was_uppercase {
-                result.push('_');
-            }
-            result.push(c.to_ascii_lowercase());
-            prev_char_was_uppercase = true;
+    /// Indicates whether this shape is a built-in Smithy type.
+    fn is_builtin(&self) -> bool {
+        self.smithy_name().starts_with("smithy.api#")
+    }
+
+    /// Returns the simple name of this shape.
+    ///
+    /// This is the portion of the Smithy name after the '#' character.
+    fn simple_name(&self) -> String {
+        let rpos = self.smithy_name().rfind('#');
+        if let Some(pos) = rpos {
+            self.smithy_name()[pos + 1..].to_string()
         } else {
-            result.push(c);
-            prev_char_was_uppercase = false;
+            self.smithy_name()
         }
     }
 
-    if RUST_IDENTS.contains(&result.as_str()) {
-        result = format!("r#{result}");
-    }
-
-    result
-}
-
-/// Indicates whether this identifier is a SCREAMING_SNAKE_CASE constant.
-pub fn is_screaming_snake_case(s: &str) -> bool {
-    s.chars().all(|c| c.is_ascii_uppercase() || c == '_')
-}
-
-/// Convert an identifier to Pascal case. This is used to convert Smithy shape names to Rust type names.
-pub fn to_pascal_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = true;
-
-    if is_screaming_snake_case(s) {
-        // Change SCREAMING_SNAKE_CASE to ScreamingSnakeCase.
-        for c in s.chars() {
-            if c == '_' {
-                capitalize_next = true;
-            } else if capitalize_next {
-                result.push(c.to_ascii_uppercase());
-                capitalize_next = false;
-            } else {
-                result.push(c.to_ascii_lowercase());
-            }
-        }
-    } else {
-        for c in s.chars() {
-            if c == '_' {
-                capitalize_next = true;
-            } else if capitalize_next {
-                result.push(c.to_ascii_uppercase());
-                capitalize_next = false;
-            } else {
-                result.push(c);
-            }
-        }
-    }
-
-    if RUST_IDENTS.contains(&result.as_str()) {
-        result = format!("r#{result}");
-    }
-
-    result
-}
-
-/// The `Typed` trait indicates that a shape is a Smithy type.
-pub trait Typed {
-    /// Returns the Rust type to use when referring to an instance of this shape.
+    /// Returns the Rust type name of this shape.
     fn rust_typename(&self) -> String;
 
-    /// Writes the implementation details of this shape to the given output.
-    fn write(&self, _output: &mut dyn Write) -> IoResult<()>;
+    /// If this shape has a function or method to parse a Clap argument, returns it. Otherwise
+    /// returns `None`.
+    fn clap_parser(&self) -> Option<String>;
 
-    /// Indicates whether this shape has a declaration in the generated code.
-    #[inline(always)]
-    fn has_decl(&self, _model: &SmithyModel) -> bool {
-        false
-    }
-
-    /// Indicates whether this shape is a primitive type.
-    #[inline(always)]
-    fn is_primitive(&self) -> bool {
-        false
-    }
-
-    /// Returns the Clap value parser to use for this shape
-    fn get_clap_parser(&self) -> String;
-
-    /// Returns the derive_builder validator, if any, to use for this shape.
-    fn get_derive_builder_validator(&self, _var: &str) -> Option<String> {
+    /// If this shape has custom code to validate its value from a builder type, returns it.
+    /// Otherwise returns `None`.
+    ///
+    /// # Parameters
+    /// * `var` — the variable holding the value to be validated.
+    /// * `field_name` — the name of the field being evaluated (for use in error messages).
+    #[allow(unused)]
+    fn derive_builder_validator(&self, var: &str, field_name: &str) -> Option<String> {
         None
     }
 
-    /// Marks this type as reachable from the input, and recursively marks any shapes targeted by this type as
-    /// reachable from the input as well.
-    fn mark_reachable_from_input(&mut self);
+    /// Mark this shape as being reachable from an input structure.
+    fn mark_reachable_from_input(&mut self) {}
+
+    /// Generate all code needed for this shape.
+    #[allow(unused)]
+    fn generate(&self, w: &mut dyn Write) -> IoResult<()> {
+        Ok(())
+    }
 }
 
-/// The `Primitive` trait indicates that a shape is a primitive Smithy type.
-pub trait Primitive: Typed {}
+/// Macro that forwards the implementation of the `ShapeInfo` trait to a contained `ShapeBase` field.
+#[macro_export]
+macro_rules! forward_shape_info {
+    ($ty:ty, $field:ident) => {
+        fn resolve(&mut self, smithy_name: &str, _: &$crate::SmithyModel) {
+            self.$field.resolve(smithy_name)
+        }
+
+        #[inline(always)]
+        fn smithy_name(&self) -> String {
+            self.$field.smithy_name()
+        }
+
+        #[inline(always)]
+        fn rust_typename(&self) -> String {
+            self.$field.rust_typename()
+        }
+    };
+}
 
 #[cfg(test)]
 mod tests {

--- a/scratchstack-shapegen/src/list.rs
+++ b/scratchstack-shapegen/src/list.rs
@@ -1,28 +1,20 @@
 use {
-    super::{Member, Typed},
+    crate::{Member, Shape, ShapeBase, ShapeInfo, SmithyModel},
+    indoc::formatdoc,
     serde::{Deserialize, Serialize},
-    serde_json::Value,
-    std::{
-        collections::HashMap,
-        io::{Result as IoResult, Write},
-    },
+    std::{cell::RefCell, rc::Rc},
 };
 
 /// The list type represents an ordered homogeneous collection of values. A list shape requires
 /// a single member named member.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct List {
-    /// The name of this list in the Smithy model.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub smithy_typename: Option<String>,
+    /// Basic shape information for the `list` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
 
-    /// The Rust name of this list.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub rust_typename: Option<String>,
+    /// The inner type of the list.
+    pub member: Member,
 
     /// Whether this struct is reachable from an API input shape. This is used to determine
     /// whether to generate Clap parsers for this struct.
@@ -30,28 +22,88 @@ pub struct List {
     /// This is resolved during a call to `SmithyModel::resolve`.
     #[serde(skip, default)]
     pub reachable_from_input: bool,
-
-    /// The member of the list.
-    pub member: Member,
-
-    /// Traits to apply to the type.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
 }
 
-impl Typed for List {
+impl ShapeInfo for List {
+    fn resolve(&mut self, smithy_name: &str, model: &SmithyModel) {
+        self.base.resolve(smithy_name);
+        self.member.resolve(smithy_name, model);
+    }
+
+    fn smithy_name(&self) -> String {
+        self.base.smithy_name()
+    }
+
     fn rust_typename(&self) -> String {
-        let member_typename = self.member.rust_typename();
-        format!("Vec<{member_typename}>")
+        if self.is_builtin() {
+            format!("::std::vec::Vec<{}>", self.member.rust_typename())
+        } else {
+            self.base.rust_typename().to_string()
+        }
     }
 
-    fn write(&self, _output: &mut dyn Write) -> IoResult<()> {
-        Ok(())
+    fn clap_parser(&self) -> Option<String> {
+        let member_typename = self.member.rust_typename();
+        Some(format!("crate::clap_utils::parse_list::<{member_typename}>"))
     }
 
-    fn get_clap_parser(&self) -> String {
-        let member_typename = self.member.rust_typename();
-        format!("crate::clap_utils::parse_list::<{member_typename}>")
+    fn derive_builder_validator(&self, var: &str, field_name: &str) -> Option<String> {
+        if self.is_builtin() {
+            return None;
+        }
+
+        let mut output = String::with_capacity(1024);
+        let simple_name = self.simple_name();
+        if let Some(lc) = self.base.traits.length_constraint() {
+            if let Some(min) = lc.min
+                && min > 0
+            {
+                let cond = if min == 1 {
+                    format!("{var}.is_empty()")
+                } else {
+                    format!("{var}.len() < {min}")
+                };
+
+                output += &formatdoc! {"
+                    if {cond} {{
+                        return ::std::result::Result::Err(
+                            format!(
+                                \"{field_name} must have at least {min} elements for {simple_name}: {{}} elements found\",
+                                {var}.len()
+                            )
+                        );
+                    }}
+                "};
+            }
+
+            if let Some(max) = lc.max {
+                output += &formatdoc! {"
+                    if {var}.len() > {max} {{
+                        return ::std::result::Result::Err(
+                            format!(
+                                \"{field_name} must have at most {max} elements for {simple_name}: {{}} elements found\",
+                                {var}.len()
+                            )
+                        );
+                    }}
+                "};
+            }
+        }
+
+        let el_validator = self.inner().borrow().derive_builder_validator("el", field_name);
+        if let Some(el_validator) = el_validator {
+            output += &formatdoc! {"
+                for el in {var}.iter() {{
+                    {el_validator}
+                }}
+            "};
+        }
+
+        if output.is_empty() {
+            None
+        } else {
+            Some(output)
+        }
     }
 
     fn mark_reachable_from_input(&mut self) {
@@ -60,5 +112,25 @@ impl Typed for List {
         }
         self.reachable_from_input = true;
         self.member.mark_reachable_from_input();
+    }
+
+    fn generate(&self, output: &mut dyn std::io::Write) -> std::io::Result<()> {
+        if self.is_builtin() {
+            return Ok(());
+        }
+
+        self.base.traits.write_docs(output, "")?;
+        writeln!(output, "pub type {} = ::std::vec::Vec<{}>;", self.base.rust_typename(), self.member.rust_typename())?;
+        writeln!(output)?;
+        Ok(())
+    }
+}
+
+impl List {
+    /// Returns the shape of the elements of this list.
+    ///
+    /// Panics if this `List` hasn't been resolved yet.
+    pub fn inner(&self) -> Rc<RefCell<Shape>> {
+        self.member.inner()
     }
 }

--- a/scratchstack-shapegen/src/map.rs
+++ b/scratchstack-shapegen/src/map.rs
@@ -1,17 +1,17 @@
 use {
-    super::{Member, Typed},
+    crate::{Member, ShapeBase, ShapeInfo, SmithyModel},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
-    std::{
-        collections::HashMap,
-        io::{Result as IoResult, Write},
-    },
+    std::io::{Result as IoResult, Write},
 };
 
 /// The map type represents a map data structure that maps string keys to homogeneous values. A
 /// map requires a member named key that MUST target a string shape and a member named value.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Map {
+    /// Basic shape information for the `map` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+
     /// The key member of the map. This member MUST target a string shape.
     ///
     /// This is resolved during a call to `SmithyModel::resolve`.
@@ -28,27 +28,27 @@ pub struct Map {
     /// This is resolved during a call to `SmithyModel::resolve`.
     #[serde(skip, default)]
     pub reachable_from_input: bool,
-
-    /// Traits to apply to the map.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
 }
 
-impl Typed for Map {
+impl ShapeInfo for Map {
+    fn smithy_name(&self) -> String {
+        self.base.smithy_name()
+    }
+
     fn rust_typename(&self) -> String {
-        let key_typename = self.key.rust_typename();
-        let value_typename = self.value.rust_typename();
-        format!("HashMap<{key_typename}, {value_typename}>")
+        self.base.rust_typename()
     }
 
-    fn write(&self, _output: &mut dyn Write) -> IoResult<()> {
-        Ok(())
+    fn resolve(&mut self, shape_name: &str, model: &SmithyModel) {
+        self.base.resolve(shape_name);
+        self.key.resolve(shape_name, model);
+        self.value.resolve(shape_name, model);
     }
 
-    fn get_clap_parser(&self) -> String {
-        let key_parser = self.key.get_clap_parser();
-        let value_parser = self.value.get_clap_parser();
-        format!("crate::clap_utils::parse_map({key_parser}, {value_parser})")
+    fn clap_parser(&self) -> Option<String> {
+        let key_parser = self.key.clap_parser().unwrap();
+        let value_parser = self.value.clap_parser().unwrap();
+        Some(format!("crate::clap_utils::parse_map({key_parser}, {value_parser})"))
     }
 
     fn mark_reachable_from_input(&mut self) {
@@ -58,5 +58,20 @@ impl Typed for Map {
         self.reachable_from_input = true;
         self.key.mark_reachable_from_input();
         self.value.mark_reachable_from_input();
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        if !self.is_builtin() {
+            // Declaration
+            let rust_typename = self.rust_typename();
+            self.base.traits.write_docs(output, "")?;
+            writeln!(
+                output,
+                "pub type {rust_typename} = ::std::collections::HashMap<{}, {}>;",
+                self.key.rust_typename(),
+                self.value.rust_typename()
+            )?;
+        }
+        Ok(())
     }
 }

--- a/scratchstack-shapegen/src/member.rs
+++ b/scratchstack-shapegen/src/member.rs
@@ -1,10 +1,8 @@
 use {
-    super::{List, Shape, Typed},
+    crate::{List, Shape, ShapeInfo, SmithyModel, TraitMap},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::{
         cell::{Ref, RefCell},
-        collections::HashMap,
         rc::Rc,
     },
 };
@@ -25,29 +23,61 @@ pub struct Member {
     pub target: String,
 
     /// A map of absolute shape IDs to trait values.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
+    #[serde(skip_serializing_if = "TraitMap::is_empty", default)]
+    pub traits: TraitMap,
+}
+
+impl ShapeInfo for Member {
+    fn resolve(&mut self, _: &str, model: &SmithyModel) {
+        assert!(self.shape.is_none());
+
+        let Some(shape) = model.shapes.get(&self.target) else {
+            panic!("Member {} does not exist in SmithyModel", self.target);
+        };
+        self.shape = Some(shape.clone());
+    }
+
+    fn smithy_name(&self) -> String {
+        self.shape.as_ref().expect("Member should be resolved before generating Rust code").borrow().smithy_name()
+    }
+
+    #[inline(always)]
+    fn rust_typename(&self) -> String {
+        self.inner().borrow().rust_typename()
+    }
+
+    #[inline(always)]
+    fn clap_parser(&self) -> Option<String> {
+        self.inner().borrow().clap_parser()
+    }
+
+    #[inline(always)]
+    fn derive_builder_validator(&self, var: &str, field_name: &str) -> Option<String> {
+        self.inner().borrow().derive_builder_validator(var, field_name)
+    }
+
+    fn mark_reachable_from_input(&mut self) {
+        self.inner().borrow_mut().mark_reachable_from_input();
+    }
 }
 
 impl Member {
-    /// Returns the inner shape of this member; panics if the member is not resolved or if the inner shape is not a [`Typed`] shape.
+    /// Returns the inner shape of this member.
+    ///
+    /// Panics if the member is not resolved.
     pub fn inner(&self) -> Rc<RefCell<Shape>> {
         self.shape.clone().expect("Member should be resolved before generating Rust code")
     }
 
-    /// Indicates whether this is an optional member.
-    pub fn is_optional(&self) -> bool {
-        !self.traits.contains_key("smithy.api#required")
+    /// Indicates whether this is a required member.
+    #[inline(always)]
+    pub fn is_required(&self) -> bool {
+        self.traits.is_required()
     }
 
-    /// Indicates whether this member is a primitive type.
-    pub fn is_primitive(&self) -> bool {
-        self.inner().borrow().is_primitive()
-    }
-
-    /// Indicates whether this member is a list type.
+    /// Indicates whether the inner shape is a list type.
     pub fn is_list(&self) -> bool {
-        matches!(&*self.inner().borrow(), Shape::List(_))
+        self.as_list().is_some()
     }
 
     /// Returns this as a list member if it is a list type; otherwise returns `None`.
@@ -60,49 +90,6 @@ impl Member {
             }))
         } else {
             None
-        }
-    }
-
-    /// Returns the bare Rust type of this member without any wrappers like `Option`.
-    pub fn bare_rust_type(&self) -> String {
-        let shape = self.shape.as_ref().expect("Member should be resolved before generating Rust code");
-        shape.borrow().rust_typename()
-    }
-}
-
-impl Typed for Member {
-    fn rust_typename(&self) -> String {
-        self.bare_rust_type()
-    }
-
-    fn write(&self, _output: &mut dyn std::io::Write) -> std::io::Result<()> {
-        // No declaration to write for members
-        Ok(())
-    }
-
-    fn has_decl(&self, _model: &super::SmithyModel) -> bool {
-        false
-    }
-
-    fn is_primitive(&self) -> bool {
-        self.inner().borrow().is_primitive()
-    }
-
-    fn get_clap_parser(&self) -> String {
-        self.shape.as_ref().expect("Member should be resolved before generating Rust code").borrow().get_clap_parser()
-    }
-
-    fn get_derive_builder_validator(&self, var: &str) -> Option<String> {
-        self.shape
-            .as_ref()
-            .expect("Member should be resolved before generating Rust code")
-            .borrow()
-            .get_derive_builder_validator(var)
-    }
-
-    fn mark_reachable_from_input(&mut self) {
-        if let Some(shape) = &self.shape {
-            shape.borrow_mut().mark_reachable_from_input();
         }
     }
 }

--- a/scratchstack-shapegen/src/operation.rs
+++ b/scratchstack-shapegen/src/operation.rs
@@ -1,21 +1,40 @@
 use {
-    super::ShapeRef,
+    crate::{Shape, ShapeBase, ShapeInfo, ShapeRef, SmithyModel},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
-    std::collections::HashMap,
+    std::{
+        cell::RefCell,
+        io::{Result as IoResult, Write},
+        rc::Rc,
+    },
 };
 
 /// The operation type represents the input, output, and possible errors of an API operation.
 /// Operation shapes are bound to resource shapes and service shapes.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Operation {
+    /// Basic shape information for this `Operation` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+
     /// Defines the optional input structure of the operation. The `input` of an operation MUST
     /// resolve to a [`Structure`][crate::Shape::Structure].
     pub input: ShapeRef,
 
+    /// The actual input shape.
+    ///
+    /// This is resolved during a call to `SmithyModel::resolve`.
+    #[serde(skip)]
+    pub input_shape: Option<Rc<RefCell<Shape>>>,
+
     /// Defines the optional output structure of the operation. The `output` of an operation MUST
     /// resolve to a [`Structure`][crate::Shape::Structure].
     pub output: ShapeRef,
+
+    /// The actual output shape.
+    ///
+    /// This is resolved during a call to `SmithyModel::resolve`.
+    #[serde(skip)]
+    pub output_shape: Option<Rc<RefCell<Shape>>>,
 
     /// Defines the list of errors that MAY be encountered when invoking the operation. Each
     /// reference MUST resolve to a [`Structure`][crate::Shape::Structure] shape that is marked with the
@@ -23,7 +42,80 @@ pub struct Operation {
     #[serde(default)]
     pub errors: Vec<ShapeRef>,
 
-    /// Traits to apply to the operation.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
+    /// The actual error shapes.
+    ///
+    /// These are resolved during a call to `SmithyModel::resolve`.
+    #[serde(skip)]
+    pub error_shapes: Vec<Rc<RefCell<Shape>>>,
+}
+
+impl ShapeInfo for Operation {
+    fn smithy_name(&self) -> String {
+        self.base.smithy_name()
+    }
+
+    fn rust_typename(&self) -> String {
+        self.base.rust_typename()
+    }
+
+    fn resolve(&mut self, shape_name: &str, model: &SmithyModel) {
+        self.base.resolve(shape_name);
+
+        if let Some(input_shape) = model.get_shape(&self.input.target) {
+            self.input_shape = Some(input_shape);
+        }
+
+        if let Some(output_shape) = model.get_shape(&self.output.target) {
+            self.output_shape = Some(output_shape);
+        }
+
+        for error_ref in &self.errors {
+            if let Some(error_shape) = model.get_shape(&error_ref.target) {
+                self.error_shapes.push(error_shape);
+            }
+        }
+    }
+
+    fn clap_parser(&self) -> Option<String> {
+        unimplemented!("clap_parser cannot be called on Operation types")
+    }
+
+    fn derive_builder_validator(&self, _: &str, _: &str) -> Option<String> {
+        unimplemented!("derive_builder_validator cannot be called on Operation types")
+    }
+
+    /// Writes Rust code representing this operation's error types.
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        let rust_typename = self.rust_typename();
+        let error_typename = format!("{rust_typename}Error");
+
+        // Write the error type declaration for this operation
+        writeln!(output, "/// Error type for the `{rust_typename}` operation")?;
+        writeln!(output, "#[derive(::std::fmt::Debug)]")?;
+        writeln!(output, "#[non_exhaustive]")?;
+        writeln!(output, "pub enum {error_typename} {{")?;
+
+        for error_shape in &self.error_shapes {
+            let Shape::Structure(error_struct) = &*error_shape.borrow() else {
+                panic!("Error shape must be a structure");
+            };
+
+            let error_rust_name = error_struct.rust_typename();
+            error_struct.base.traits.write_docs(output, "    ")?;
+            writeln!(output, "    {error_rust_name}({error_rust_name}),")?;
+        }
+        writeln!(
+            output,
+            "    /// An unexpected error occurred (e.g., invalid JSON returned by the service or an unknown error code)."
+        )?;
+        writeln!(output, "    #[allow(deprecated)]")?;
+        writeln!(
+            output,
+            "    #[deprecated(note = \"Matching `Unhandled` directly is not forwards compatible. Instead, match using a variable wildcard pattern and check `.code()`: `if err.code() == Some(\\\"SpecificiExceptionCode\\\") => {{ /* handle the error */ }}\")]"
+        )?;
+        writeln!(output, "    Unhandled(crate::error::sealed_unhandled::Unhandled),")?;
+
+        writeln!(output, "}}")?;
+        Ok(())
+    }
 }

--- a/scratchstack-shapegen/src/primitive.rs
+++ b/scratchstack-shapegen/src/primitive.rs
@@ -1,78 +1,428 @@
 use {
-    crate::{Primitive, Typed},
+    crate::{ShapeBase, ShapeInfo, TraitMap, forward_shape_info},
+    indoc::formatdoc,
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::io::{Result as IoResult, Write},
 };
 
-macro_rules! decl {
-    ($shape:ident, $rust_type:ty) => {
-        #[allow(missing_docs)]
-        #[derive(Clone, Debug, Deserialize, Serialize)]
-        pub struct $shape {
-            /// The name of this type in the Smithy model.
-            ///
-            /// This is resolved during a call to `SmithyModel::resolve`.
-            #[serde(skip, default)]
-            pub smithy_typename: ::std::option::Option<::std::string::String>,
+/// The `unit` type in Smithy is similar to `Void` and `None` in other languages. It is used
+/// when the input or output of an operation has no meaningful value or if a union member has no
+/// meaningful value.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyUnit {
+    /// Basic shape information for the `unit` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
 
-            /// The Rust name of this type.
-            ///
-            /// This is resolved during a call to `SmithyModel::resolve`.
-            #[serde(skip, default)]
-            pub rust_typename: ::std::option::Option<::std::string::String>,
+/// A `boolean` is a Boolean value type.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyBoolean {
+    /// Basic shape information for the `boolean` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
 
-            /// Traits to apply to the type.
-            #[serde(skip_serializing_if = "::std::collections::HashMap::is_empty", default)]
-            pub traits: ::std::collections::HashMap<::std::string::String, Value>,
+/// A `blob` is uninterpreted binary data.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyBlob {
+    /// Basic shape information for the `blob` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `string` is a UTF-8 encoded string.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyString {
+    /// Basic shape information for the `string` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `bigInteger` is an arbitrarily large signed integer.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyBigInteger {
+    /// Basic shape information for the `bigInteger` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `bigDecimal` is an arbitrary precision signed decimal number.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyBigDecimal {
+    /// Basic shape information for the `bigDecimal` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `timestamp` represents an instant in time in the proleptic Gregorian calendar, independent
+/// of local times or timezones. Timestamps support an allowable date range between midnight
+/// January 1, 0001 CE to 23:59:59.999 on December 31, 9999 CE, with a temporal resolution of
+/// 1 millisecond. This resolution and range ensures broad support across programming languages
+/// and guarantees compatibility with RFC 3339.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyTimestamp {
+    /// Basic shape information for the `timestamp` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `document` represents protocol-agnostic open content that functions as a kind of "any"
+/// type. Document types are represented by a JSON-like data model and can contain UTF-8
+/// strings, arbitrary precision numbers, booleans, nulls, a list of these values, and a map of
+/// UTF-8 strings to these values. Open content is useful for modeling unstructured data that
+/// has no schema, data that can't be modeled using rigid types, or data that has a schema that
+/// evolves outside of the purview of a model. The serialization format of a document is an
+/// implementation detail of a protocol and MUST NOT have any effect on the types exposed by
+/// tooling to represent a document value.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyDocument {
+    /// Basic shape information for the `document` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `byte` is an 8-bit signed integer ranging from -128 to 127 (inclusive).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyByte {
+    /// Basic shape information for the `byte` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `short` is a 16-bit signed integer ranging from -32,768 to 32,767 (inclusive).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyShort {
+    /// Basic shape information for the `short` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// An `integer` is a 32-bit signed integer ranging from -2^31 to (2^31)-1 (inclusive).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyInteger {
+    /// Basic shape information for the `integer` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `long` is a 64-bit signed integer ranging from -2^63 to (2^63)-1 (inclusive).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyLong {
+    /// Basic shape information for the `long` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `float` is a single precision IEEE-754 floating point number.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyFloat {
+    /// Basic shape information for the `float` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+/// A `double` is a double precision IEEE-754 floating point number.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SmithyDouble {
+    /// Basic shape information for the `double` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+}
+
+impl ShapeInfo for SmithyUnit {
+    forward_shape_info!(SmithyUnit, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        None
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        if !self.is_builtin() {
+            self.base.traits.write_docs(output, "")?;
+            writeln!(output, "pub type {} = ();", self.rust_typename())?;
+        }
+        Ok(())
+    }
+}
+
+impl SmithyUnit {
+    /// Create a new `SmithyUnit` instance with the given Smithy name.
+    pub fn new(smithy_name: impl Into<String>) -> Self {
+        let base = ShapeBase {
+            smithy_name: Some(smithy_name.into()),
+            rust_typename: Some("()".to_string()),
+            traits: TraitMap::new(),
+        };
+        Self {
+            base,
+        }
+    }
+}
+
+impl ShapeInfo for SmithyBoolean {
+    forward_shape_info!(SmithyBoolean, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        None
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        if !self.is_builtin() {
+            // Declaration
+            let rust_typename = self.rust_typename();
+            self.base.traits.write_docs(output, "")?;
+            writeln!(output, "pub type {rust_typename} = bool;")?;
+            writeln!(output)?;
+        }
+        Ok(())
+    }
+}
+
+impl ShapeInfo for SmithyBlob {
+    forward_shape_info!(SmithyBlob, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        // TODO: Determine how we want to handle blobs on the command line.
+        todo!("Determine how to handle blobs on the CLI")
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        if !self.is_builtin() {
+            // Declaration
+            let rust_typename = self.rust_typename();
+            self.base.traits.write_docs(output, "")?;
+            writeln!(output, "pub type {rust_typename} = Vec<u8>;")?;
+            writeln!(output)?;
+
+            // Clap parser
+            let simple_name = self.simple_name();
+            writeln!(output, "#[cfg(feature = \"clap\")]")?;
+            writeln!(output, "#[allow(non_snake_case, unused)]")?;
+            writeln!(output, "fn clap_parse_{rust_typename}(s: &str) -> Result<Vec<u8>, String> {{")?;
+            writeln!(output, "    let value = ::base64::engine::Engine::decode(")?;
+            writeln!(output, "        &::base64::engine::general_purpose::STANDARD, s)")?;
+            writeln!(output, "        .map_err(|_| \"{simple_name} must be a valid base64 string\".to_string())?;")?;
+            writeln!(output, "    Ok(value)")?;
+            writeln!(output, "}}")?;
+            writeln!(output)?;
+        }
+        Ok(())
+    }
+}
+
+impl ShapeInfo for SmithyString {
+    forward_shape_info!(SmithyString, base);
+
+    #[inline(always)]
+    fn clap_parser(&self) -> Option<String> {
+        if self.is_builtin() {
+            None
+        } else {
+            Some(format!("clap_parse_{}", self.rust_typename()))
+        }
+    }
+
+    #[inline(always)]
+    fn derive_builder_validator(&self, var: &str, field_name: &str) -> Option<String> {
+        if self.is_builtin() {
+            return None;
         }
 
-        impl Primitive for $shape {}
-    };
+        let simple_name = self.simple_name(); // Used in error messages
+        let mut output = String::with_capacity(1024);
+
+        if let Some(pat) = self.base.traits.pattern() {
+            let escaped_pat = pat.replace("\\", "\\\\").replace("\"", "\\\"").replace("{", "{{").replace("}", "}}");
+            output += &formatdoc!("
+                static PAT: ::std::sync::LazyLock<::regex::Regex> = ::std::sync::LazyLock::new(||::regex::Regex::new(r\"{pat}\").expect(\"Invalid regex pattern in Smithy model\"));
+                if !PAT.is_match({var}) {{
+                    return Err(format!(\"{field_name} must match the regex {escaped_pat} for {simple_name}: {{{var}}}\"));
+                }}
+            ");
+        }
+
+        if let Some(lc) = self.base.traits.length_constraint() {
+            if let Some(min) = lc.min
+                && min > 0
+            {
+                let cond = if min > 1 {
+                    format!("{var}.len() < {min}")
+                } else {
+                    format!("{var}.is_empty()")
+                };
+
+                output += &formatdoc!("
+                    if {cond} {{
+                        return Err(format!(\"{field_name} must be at least {min} characters long for {simple_name}: {{{var}}}\"));
+                    }}
+                ");
+            }
+
+            if let Some(max) = lc.max {
+                output += &formatdoc!("
+                    if {var}.len() > {max} {{
+                        return Err(format!(\"{field_name} must be at most {max} characters long for {simple_name}: {{{var}}}\")); 
+                    }}
+                ");
+            }
+        }
+
+        if !output.is_empty() {
+            Some(output)
+        } else {
+            None
+        }
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        if !self.is_builtin() {
+            // Declaration
+            let rust_typename = self.rust_typename();
+            self.base.traits.write_docs(output, "")?;
+            writeln!(output, "pub type {} = ::std::string::String;", rust_typename)?;
+            writeln!(output)?;
+
+            // Clap parser
+            let rust_typename = self.rust_typename();
+            let simple_name = self.simple_name();
+            writeln!(output, "#[cfg(feature = \"clap\")]")?;
+            writeln!(output, "#[allow(non_snake_case, unused)]")?;
+            writeln!(output, "fn clap_parse_{rust_typename}(s: &str) -> Result<String, String> {{")?;
+
+            if let Some(pat) = self.base.traits.pattern() {
+                writeln!(
+                    output,
+                    "    static PAT: ::std::sync::LazyLock<::regex::Regex> = ::std::sync::LazyLock::new(||::regex::Regex::new(r\"{pat}\").expect(\"Invalid regex pattern in Smithy model\"));"
+                )?;
+                writeln!(output, "    if !PAT.is_match(s) {{")?;
+                writeln!(output, "        return Err(r##\"{simple_name} must match the regex {pat}\"##.to_string());")?;
+                writeln!(output, "    }}")?;
+            }
+
+            if let Some(lc) = self.base.traits.length_constraint() {
+                if let Some(min) = lc.min
+                    && min > 0
+                {
+                    if min == 1 {
+                        writeln!(output, "    if s.is_empty() {{")?;
+                    } else {
+                        writeln!(output, "    if s.len() < {min} {{")?;
+                    }
+                    writeln!(
+                        output,
+                        "        return Err(\"{simple_name} must be at least {min} characters long\".to_string());"
+                    )?;
+                    writeln!(output, "    }}")?;
+                }
+
+                if let Some(max) = lc.max {
+                    writeln!(output, "    if s.len() > {max} {{")?;
+                    writeln!(
+                        output,
+                        "        return Err(\"{simple_name} must be at most {max} characters long\".to_string());"
+                    )?;
+                    writeln!(output, "    }}")?;
+                }
+            }
+
+            writeln!(output, "    Ok(s.to_string())")?;
+            writeln!(output, "}}")?;
+            writeln!(output)?;
+        }
+        Ok(())
+    }
+}
+
+impl ShapeInfo for SmithyBigInteger {
+    forward_shape_info!(SmithyBigInteger, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        todo!("Determine how to handle BigInteger arguments on the CLI")
+    }
+}
+
+impl ShapeInfo for SmithyBigDecimal {
+    forward_shape_info!(SmithyBigDecimal, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        todo!("Determine how to handle BigDecimal arguments on the CLI")
+    }
+}
+
+impl ShapeInfo for SmithyTimestamp {
+    forward_shape_info!(SmithyTimestamp, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        let rust_typename = self.rust_typename();
+        Some(format!("{rust_typename}::try_from::<&str>"))
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        if !self.is_builtin() {
+            // Declaration
+            let rust_typename = self.rust_typename();
+            self.base.traits.write_docs(output, "")?;
+            writeln!(output, "pub type {} = ::chrono::DateTime<chrono::Utc>;", rust_typename)?;
+            writeln!(output)?;
+
+            // Clap parser
+            let simple_name = self.simple_name();
+
+            writeln!(output, "#[cfg(feature = \"clap\")]")?;
+            writeln!(output, "#[allow(non_snake_case, unused)]")?;
+            writeln!(
+                output,
+                "fn clap_parse_{rust_typename}(s: &str) -> Result<::chrono::DateTime<chrono::Utc>, String> {{"
+            )?;
+            writeln!(output, "    s.parse().map_err(|_| format!(\"{simple_name} must be a valid timestamp: {{s}}\"))")?;
+            writeln!(output, "}}")?;
+            writeln!(output)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ShapeInfo for SmithyDocument {
+    forward_shape_info!(SmithyDocument, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        todo!("Figure out how to implement clap_parser for Document")
+    }
 }
 
 macro_rules! impl_numeric {
     ($shape:ident, $rust_type:ty, $range_json:ident) => {
-        impl Typed for $shape {
-            fn rust_typename(&self) -> ::std::string::String {
-                self.rust_typename.clone().expect(concat!(stringify!($shape), " shape should have a Rust typename after resolution"))
+        impl ShapeInfo for $shape {
+            forward_shape_info!($shape, base);
+
+            fn clap_parser(&self) -> Option<String> {
+                if self.is_builtin() {
+                    None
+                } else {
+                    Some(format!("clap_parse_{}", self.rust_typename()))
+                }
             }
 
-            #[inline(always)]
-            fn is_primitive(&self) -> bool {
-                true
-            }
-
-            fn get_clap_parser(&self) -> ::std::string::String {
-                let rust_typename = self.rust_typename();
-                format!("clap_parse_{rust_typename}")
-            }
-
-            fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-                self.write_rust_decl(output)?;
-                self.write_clap_parser(output)?;
+            fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+                if !self.is_builtin() {
+                    self.write_rust_decl(output)?;
+                    self.write_clap_parser(output)?;
+                }
                 Ok(())
             }
 
-            #[inline(always)]
-            fn mark_reachable_from_input(&mut self) {}
+            fn derive_builder_validator(&self, var: &str, field_name: &str) -> Option<String> {
+                let simple_name = self.simple_name();
+                let mut output = String::new();
 
-            fn get_derive_builder_validator(&self, var: &str) -> ::std::option::Option<::std::string::String> {
-                let mut output = ::std::string::String::new();
-                let smithy_typename = self.smithy_typename.as_ref().expect(concat!(stringify!($shape), " shape should have a Smithy typename after resolution"));
-                let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-                let simple_typename = &smithy_typename[hash_pos + 1..];
-
-                if let Some(rc) = self.traits.get("smithy.api#range") {
-                    let rc = rc.as_object().expect("Range trait should be an object");
-                    let min = rc.get("min").and_then(|v| v.$range_json());
-                    let max = rc.get("max").and_then(|v| v.$range_json());
-
-                    if let Some(min) = min {
-                        output += &format!("if *{var} < {min} {{ return Err(format!(\"{simple_typename} must be >= {min}: {{{var}}}\")); }}\n");
+                if let Some(rc) = self.base.traits.range_constraint() {
+                    if let Some(min) = rc.min {
+                        output += &format!("if *{var} < {min} {{ return Err(format!(\"{field_name} for {simple_name} must be >= {min}: {{{var}}}\")); }}\n");
                     }
-                    if let Some(max) = max {
-                        output += &format!("if *{var} > {max} {{ return Err(format!(\"{simple_typename} must be <= {max}: {{{var}}}\")); }}\n");
+                    if let Some(max) = rc.max {
+                        output += &format!("if *{var} > {max} {{ return Err(format!(\"{field_name} for {simple_name} must be <= {max}: {{{var}}}\")); }}\n");
                     }
                 }
 
@@ -83,48 +433,35 @@ macro_rules! impl_numeric {
         impl $shape {
             /// Writes the Rust declaration for the type alias.
             fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
-                let rust_typename = self.rust_typename();
-                let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-                if let Some(docs) = docs {
-                    for line in docs.lines() {
-                        writeln!(output, "/// {}", line.trim())?;
-                    }
-                } else {
-                    writeln!(output, "#[allow(missing_docs)]")?;
+                if !self.is_builtin() {
+                    self.base.traits.write_docs(output, "")?;
+                    let rust_typename = self.rust_typename();
+                    writeln!(output, "pub type {} = {};", rust_typename, stringify!($rust_type))?;
+                    writeln!(output)?;
                 }
-                writeln!(output, "pub type {} = {};", rust_typename, stringify!($rust_type))?;
-                writeln!(output)?;
-
                 Ok(())
             }
 
             /// Writes the clap parser for this type.
             fn write_clap_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-                let smithy_typename = self.smithy_typename.as_ref().expect(concat!(stringify!($shape), " shape should have a Smithy typename after resolution"));
-                let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-                let simple_typename = &smithy_typename[hash_pos + 1..];
                 let rust_typename = self.rust_typename();
-                let fn_name = format!("clap_parse_{}", rust_typename);
+                let simple_name = self.simple_name();
                 let return_type = stringify!($rust_type).to_string();
 
                 writeln!(output, "#[cfg(feature = \"clap\")]")?;
                 writeln!(output, "#[allow(non_snake_case, unused)]")?;
-                writeln!(output, "fn {fn_name}(s: &str) -> Result<{return_type}, String> {{")?;
-                writeln!(output, "    let value = s.parse().map_err(|_| format!(\"Invalid {simple_typename}: {{s}}\"))?;")?;
+                writeln!(output, "fn clap_parse_{rust_typename}(s: &str) -> Result<{return_type}, String> {{")?;
+                writeln!(output, "    let value = s.parse().map_err(|_| format!(\"Invalid {simple_name}: {{s}}\"))?;")?;
 
-                if let Some(rc) = self.traits.get("smithy.api#range") {
-                    let rc = rc.as_object().expect("Range trait should be an object");
-                    let min = rc.get("min").and_then(|v| v.$range_json());
-                    let max = rc.get("max").and_then(|v| v.$range_json());
-
-                    if let Some(min) = min {
+                if let Some(rc) = self.base.traits.range_constraint() {
+                    if let Some(min) = rc.min {
                         writeln!(output, "    if value < {min} {{")?;
-                        writeln!(output, "        return Err(format!(\"{simple_typename} must be >= {min}: {{s}}\"));")?;
+                        writeln!(output, "        return Err(format!(\"{simple_name} must be >= {min}: {{s}}\"));")?;
                         writeln!(output, "    }}")?;
                     }
-                    if let Some(max) = max {
+                    if let Some(max) = rc.max {
                         writeln!(output, "    if value > {max} {{")?;
-                        writeln!(output, "        return Err(format!(\"{simple_typename} must be <= {max}: {{s}}\"));")?;
+                        writeln!(output, "        return Err(format!(\"{simple_name} must be <= {max}: {{s}}\"));")?;
                         writeln!(output, "    }}")?;
                     }
                 }
@@ -138,412 +475,9 @@ macro_rules! impl_numeric {
     }
 }
 
-macro_rules! make_int_type {
-    ($shape:ident, $rust_type:ty) => {
-        decl!($shape, $rust_type);
-        impl_numeric!($shape, $rust_type, as_i64);
-    };
-}
-
-macro_rules! make_float_type {
-    ($shape:ident, $rust_type:ty) => {
-        decl!($shape, $rust_type);
-        impl_numeric!($shape, $rust_type, as_f64);
-    };
-}
-
-make_int_type!(Byte, i8);
-make_int_type!(Short, i16);
-make_int_type!(Integer, i32);
-make_int_type!(Long, i64);
-
-make_int_type!(BigInteger, ::num_bigint::BigInt);
-
-make_float_type!(Float, f32);
-make_float_type!(Double, f64);
-make_float_type!(BigDecimal, ::bigdecimal::BigDecimal);
-
-decl!(Blob, Vec<u8>);
-decl!(Boolean, bool);
-decl!(String, ::std::string::String);
-decl!(Timestamp, ::chrono::DateTime<::chrono::Utc>);
-decl!(Unit, ());
-
-impl Typed for Blob {
-    fn rust_typename(&self) -> ::std::string::String {
-        self.rust_typename.clone().expect("Blob shape should have a Rust typename after resolution")
-    }
-
-    #[inline(always)]
-    fn is_primitive(&self) -> bool {
-        true
-    }
-
-    fn get_clap_parser(&self) -> ::std::string::String {
-        unimplemented!("blob type does not have a clap parser")
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl(output)?;
-        self.write_clap_parser(output)?;
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn mark_reachable_from_input(&mut self) {}
-}
-
-impl Blob {
-    fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
-        let rust_typename = self.rust_typename();
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
-
-        writeln!(output, "pub type {} = Vec<u8>;", rust_typename)?;
-        writeln!(output)?;
-        Ok(())
-    }
-
-    fn write_clap_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("Blob shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
-        let rust_typename = self.rust_typename();
-        let fn_name = format!("clap_parse_{}", rust_typename);
-
-        writeln!(output, "#[cfg(feature = \"clap\")]")?;
-        writeln!(output, "#[allow(non_snake_case, unused)]")?;
-        writeln!(output, "fn {fn_name}(s: &str) -> Result<Vec<u8>, String> {{")?;
-        writeln!(
-            output,
-            "    let value = ::base64::engine::Engine::decode(&::base64::engine::general_purpose::STANDARD, s).map_err(|_| \"{simple_typename} must be a valid base64 string\".to_string())?;"
-        )?;
-        writeln!(output, "    Ok(value)")?;
-        writeln!(output, "}}")?;
-        writeln!(output)?;
-        Ok(())
-    }
-}
-
-impl Typed for Boolean {
-    fn rust_typename(&self) -> ::std::string::String {
-        self.rust_typename.clone().expect("Boolean shape should have a Rust typename after resolution")
-    }
-
-    #[inline(always)]
-    fn is_primitive(&self) -> bool {
-        true
-    }
-
-    fn get_clap_parser(&self) -> ::std::string::String {
-        let rust_typename = self.rust_typename();
-        format!("clap_parse_{rust_typename}")
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl(output)?;
-        self.write_clap_parser(output)?;
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn mark_reachable_from_input(&mut self) {}
-}
-
-impl Boolean {
-    fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
-        let rust_typename = self.rust_typename();
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
-        writeln!(output, "pub type {} = bool;", rust_typename)?;
-        writeln!(output)?;
-
-        Ok(())
-    }
-
-    fn write_clap_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("Boolean shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
-        let rust_typename = self.rust_typename();
-        let fn_name = format!("clap_parse_{}", rust_typename);
-
-        writeln!(output, "#[cfg(feature = \"clap\")]")?;
-        writeln!(output, "#[allow(non_snake_case, unused)]")?;
-        writeln!(output, "fn {fn_name}(s: &str) -> Result<bool, String> {{")?;
-        writeln!(output, "    s.parse().map_err(|_| format!(\"{simple_typename} must be a valid boolean: {{s}}\"))")?;
-        writeln!(output, "}}")?;
-        writeln!(output)?;
-        Ok(())
-    }
-}
-
-impl Typed for String {
-    fn rust_typename(&self) -> ::std::string::String {
-        self.rust_typename.clone().expect("String shape should have a Rust typename after resolution")
-    }
-
-    #[inline(always)]
-    fn is_primitive(&self) -> bool {
-        true
-    }
-
-    fn get_clap_parser(&self) -> ::std::string::String {
-        let rust_typename = self.rust_typename();
-        format!("clap_parse_{rust_typename}")
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl(output)?;
-        self.write_clap_parser(output)?;
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn mark_reachable_from_input(&mut self) {}
-
-    fn get_derive_builder_validator(&self, field: &str) -> ::std::option::Option<::std::string::String> {
-        let mut output = ::std::string::String::new();
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("String shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
-
-        if let Some(pat) = self.traits.get("smithy.api#pattern").and_then(|v| v.as_str()) {
-            let escaped_pat = pat.replace("\\", "\\\\").replace("\"", "\\\"").replace("{", "{{").replace("}", "}}");
-            output += &format!(
-                "static PAT: ::std::sync::LazyLock<::regex::Regex> = ::std::sync::LazyLock::new(||::regex::Regex::new(r\"{pat}\").expect(\"Invalid regex pattern in Smithy model\"));\n"
-            );
-            output += &format!(
-                "if !PAT.is_match({field}) {{ return Err(format!(\"{simple_typename} must match the regex {escaped_pat}: {{{field}}}\")); }}\n"
-            );
-        }
-
-        if let Some(lc) = self.traits.get("smithy.api#length") {
-            let lc = lc.as_object().expect("Length trait should be an object");
-            let min = lc.get("min").and_then(|v| v.as_u64());
-            let max = lc.get("max").and_then(|v| v.as_u64());
-
-            if let Some(min) = min
-                && min > 0
-            {
-                if min > 1 {
-                    output += &format!("if {field}.len() < {min} ");
-                } else {
-                    output += &format!("if {field}.is_empty() ");
-                }
-
-                output += &format!(
-                    "{{ return Err(format!(\"{simple_typename} must be at least {min} characters long: {{{field}}}\")); }}\n"
-                );
-            }
-
-            if let Some(max) = max {
-                output += &format!(
-                    "if {field}.len() > {max} {{ return Err(format!(\"{simple_typename} must be at most {max} characters long: {{{field}}}\")); }}\n"
-                );
-            }
-        }
-
-        if !output.is_empty() {
-            Some(output)
-        } else {
-            None
-        }
-    }
-}
-
-impl String {
-    /// Writes the Rust declaration for the type alias.
-    fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
-        let rust_typename = self.rust_typename();
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
-        writeln!(output, "pub type {} = String;", rust_typename)?;
-        writeln!(output)?;
-
-        Ok(())
-    }
-
-    /// Writes the clap parser for this type.
-    fn write_clap_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("String shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
-        let rust_typename = self.rust_typename();
-        let fn_name = format!("clap_parse_{}", rust_typename);
-
-        writeln!(output, "#[cfg(feature = \"clap\")]")?;
-        writeln!(output, "#[allow(non_snake_case, unused)]")?;
-        writeln!(output, "fn {fn_name}(s: &str) -> Result<String, String> {{")?;
-
-        if let Some(pat) = self.traits.get("smithy.api#pattern").and_then(|v| v.as_str()) {
-            writeln!(
-                output,
-                "    static PAT: ::std::sync::LazyLock<::regex::Regex> = ::std::sync::LazyLock::new(||::regex::Regex::new(r\"{pat}\").expect(\"Invalid regex pattern in Smithy model\"));"
-            )?;
-            writeln!(output, "    if !PAT.is_match(s) {{")?;
-            writeln!(output, "        return Err(r##\"{simple_typename} must match the regex {pat}\"##.to_string());")?;
-            writeln!(output, "    }}")?;
-        }
-
-        if let Some(lc) = self.traits.get("smithy.api#length") {
-            let lc = lc.as_object().expect("Length trait should be an object");
-            let min = lc.get("min").and_then(|v| v.as_u64());
-            let max = lc.get("max").and_then(|v| v.as_u64());
-
-            if let Some(min) = min
-                && min > 0
-            {
-                if min == 1 {
-                    writeln!(output, "    if s.is_empty() {{")?;
-                } else {
-                    writeln!(output, "    if s.len() < {min} {{")?;
-                }
-                writeln!(
-                    output,
-                    "        return Err(\"{simple_typename} must be at least {min} characters long\".to_string());"
-                )?;
-                writeln!(output, "    }}")?;
-            }
-
-            if let Some(max) = max {
-                writeln!(output, "    if s.len() > {max} {{")?;
-                writeln!(
-                    output,
-                    "        return Err(\"{simple_typename} must be at most {max} characters long\".to_string());"
-                )?;
-                writeln!(output, "    }}")?;
-            }
-        }
-
-        writeln!(output, "    Ok(s.to_string())")?;
-        writeln!(output, "}}")?;
-        writeln!(output)?;
-
-        Ok(())
-    }
-}
-
-impl Typed for Timestamp {
-    fn rust_typename(&self) -> ::std::string::String {
-        self.rust_typename.clone().expect("Timestamp shape should have a Rust typename after resolution")
-    }
-
-    #[inline(always)]
-    fn is_primitive(&self) -> bool {
-        true
-    }
-
-    fn get_clap_parser(&self) -> ::std::string::String {
-        let rust_typename = self.rust_typename();
-        format!("{rust_typename}::try_from::<&str>")
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl_body(output)?;
-        self.write_clap_parser(output)?;
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn mark_reachable_from_input(&mut self) {}
-}
-
-impl Timestamp {
-    /// Writes the Rust declaration for the type alias.
-    fn write_rust_decl_body(&self, output: &mut dyn Write) -> IoResult<()> {
-        let rust_typename = self.rust_typename();
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
-        writeln!(output, "pub type {} = chrono::DateTime<chrono::Utc>;", rust_typename)?;
-        writeln!(output)?;
-
-        Ok(())
-    }
-
-    /// Writes the clap parser for this type.
-    fn write_clap_parser(&self, output: &mut dyn Write) -> IoResult<()> {
-        let smithy_typename =
-            self.smithy_typename.as_ref().expect("Timestamp shape should have a Smithy typename after resolution");
-        let hash_pos = smithy_typename.rfind("#").expect("Smithy typename should contain a '#' character");
-        let simple_typename = &smithy_typename[hash_pos + 1..];
-        let rust_typename = self.rust_typename();
-        let fn_name = format!("clap_parse_{}", rust_typename);
-
-        writeln!(output, "#[cfg(feature = \"clap\")]")?;
-        writeln!(output, "#[allow(non_snake_case, unused)]")?;
-        writeln!(output, "fn {fn_name}(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {{")?;
-        writeln!(output, "    s.parse().map_err(|_| format!(\"{simple_typename} must be a valid timestamp: {{s}}\"))")?;
-        writeln!(output, "}}")?;
-        writeln!(output)?;
-
-        Ok(())
-    }
-}
-
-impl Typed for Unit {
-    fn rust_typename(&self) -> ::std::string::String {
-        self.rust_typename.clone().expect("Unit shape should have a Rust typename after resolution")
-    }
-
-    #[inline(always)]
-    fn is_primitive(&self) -> bool {
-        true
-    }
-
-    fn get_clap_parser(&self) -> ::std::string::String {
-        unimplemented!("unit type does not have a clap parser")
-    }
-
-    #[inline(always)]
-    fn mark_reachable_from_input(&mut self) {}
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl(output)
-    }
-}
-
-impl Unit {
-    fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
-        writeln!(output, "pub type {} = ();", self.rust_typename())?;
-        writeln!(output)?;
-
-        Ok(())
-    }
-}
+impl_numeric!(SmithyByte, i8, as_i64);
+impl_numeric!(SmithyShort, i16, as_i64);
+impl_numeric!(SmithyInteger, i32, as_i64);
+impl_numeric!(SmithyLong, i64, as_i64);
+impl_numeric!(SmithyFloat, f32, as_f64);
+impl_numeric!(SmithyDouble, f64, as_f64);

--- a/scratchstack-shapegen/src/range_constraint.rs
+++ b/scratchstack-shapegen/src/range_constraint.rs
@@ -1,0 +1,9 @@
+/// A range constraint associated with a shape.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RangeConstraint {
+    /// The lower bound, if any.
+    pub min: Option<i64>,
+
+    /// The upper bound, if any.
+    pub max: Option<i64>,
+}

--- a/scratchstack-shapegen/src/resource.rs
+++ b/scratchstack-shapegen/src/resource.rs
@@ -1,7 +1,6 @@
 use {
-    super::ShapeRef,
+    super::{ShapeBase, ShapeInfo, ShapeRef, forward_shape_info},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::collections::HashMap,
 };
 
@@ -9,6 +8,10 @@ use {
 /// resource shape is defined in the IDL using a resource_statement.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Resource {
+    /// Basic shape information for this resource.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+
     /// Defines identifier names and shape IDs used to identify the resource.
     #[serde(default)]
     pub identifiers: HashMap<String, ShapeRef>,
@@ -60,8 +63,16 @@ pub struct Resource {
     /// reference MUST target a resource.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub resources: Vec<ShapeRef>,
+}
 
-    /// Traits to apply to the resource.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
+impl ShapeInfo for Resource {
+    forward_shape_info!(Resource, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        unimplemented!("clap_parser cannot be called on Resource types")
+    }
+
+    fn derive_builder_validator(&self, _: &str, _: &str) -> Option<String> {
+        unimplemented!("derive_builder_validator cannot be called on Resource types")
+    }
 }

--- a/scratchstack-shapegen/src/service.rs
+++ b/scratchstack-shapegen/src/service.rs
@@ -1,7 +1,6 @@
 use {
-    super::ShapeRef,
+    super::{ShapeBase, ShapeInfo, ShapeRef, forward_shape_info},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::collections::HashMap,
 };
 
@@ -9,6 +8,10 @@ use {
 /// The resources and operations of an API are bound within the closure of a service.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Service {
+    /// Basic shape information for this service.
+    #[serde(flatten)]
+    pub base: ShapeBase,
+
     /// Defines the version of the service. The version can be provided in any format (e.g.,
     /// `2017-02-11`, `2.0`, etc).
     #[serde(default)]
@@ -28,11 +31,19 @@ pub struct Service {
     #[serde(default)]
     pub errors: Vec<ShapeRef>,
 
-    /// Traits to apply to the service
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
-
     /// Disambiguates shape name conflicts in the service closure.
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub rename: HashMap<String, String>,
+}
+
+impl ShapeInfo for Service {
+    forward_shape_info!(Service, base);
+
+    fn clap_parser(&self) -> Option<String> {
+        unimplemented!("clap_parser cannot be called on Service types")
+    }
+
+    fn derive_builder_validator(&self, _: &str, _: &str) -> Option<String> {
+        unimplemented!("derive_builder_validator cannot be called on Service types")
+    }
 }

--- a/scratchstack-shapegen/src/shape.rs
+++ b/scratchstack-shapegen/src/shape.rs
@@ -1,9 +1,11 @@
 use {
-    super::{Enum, IntEnum, List, Map, Member, Operation, Resource, Service, Structure, Typed, Union, primitive},
+    crate::{
+        Enum, IntEnum, List, Map, Member, Operation, Resource, Service, ShapeInfo, SmithyModel, Structure, TraitMap,
+        Union, primitive,
+    },
     serde::{Deserialize, Serialize},
-    serde_json::Value as JsonValue,
     std::{
-        collections::HashMap,
+        collections::BTreeMap,
         io::{Result as IoResult, Write},
     },
 };
@@ -16,51 +18,59 @@ pub enum Shape {
     /// when the input or output of an operation has no meaningful value or if a union member has no
     /// meaningful value.
     #[serde(rename = "unit")]
-    Unit(primitive::Unit),
+    Unit(primitive::SmithyUnit),
 
     /// A `blob` is uninterpreted binary data.
     #[serde(rename = "blob")]
-    Blob(primitive::Blob),
+    Blob(primitive::SmithyBlob),
 
     /// A `boolean` is a Boolean value type.
     #[serde(rename = "boolean")]
-    Boolean(primitive::Boolean),
-
-    /// A `string` is a UTF-8 encoded string.
-    #[serde(rename = "string")]
-    String(primitive::String),
-
-    /// A `byte` is an 8-bit signed integer ranging from -128 to 127 (inclusive).
-    #[serde(rename = "byte")]
-    Byte(primitive::Byte),
-
-    /// A `short` is a 16-bit signed integer ranging from -32,768 to 32,767 (inclusive).
-    #[serde(rename = "short")]
-    Short(primitive::Short),
-
-    /// An `integer` is a 32-bit signed integer ranging from -2^31 to (2^31)-1 (inclusive).
-    #[serde(rename = "integer")]
-    Integer(primitive::Integer),
-
-    /// A `long` is a 64-bit signed integer ranging from -2^63 to (2^63)-1 (inclusive).
-    #[serde(rename = "long")]
-    Long(primitive::Long),
-
-    /// A `float` is a single precision IEEE-754 floating point number.
-    #[serde(rename = "float")]
-    Float(primitive::Float),
-
-    /// A `double` is a double precision IEEE-754 floating point number.
-    #[serde(rename = "double")]
-    Double(primitive::Double),
+    Boolean(primitive::SmithyBoolean),
 
     /// A `bigInteger` is an arbitrarily large signed integer.
     #[serde(rename = "bigInteger")]
-    BigInteger(primitive::BigInteger),
+    BigInteger(primitive::SmithyBigInteger),
 
     /// A `bigDecimal` is an arbitrary precision signed decimal number.
     #[serde(rename = "bigDecimal")]
-    BigDecimal(primitive::BigDecimal),
+    BigDecimal(primitive::SmithyBigDecimal),
+
+    /// A `string` is a UTF-8 encoded string.
+    #[serde(rename = "string")]
+    String(primitive::SmithyString),
+
+    /// A `timestamp` represents an instant in time in the proleptic Gregorian calendar, independent
+    /// of local times or timezones. Timestamps support an allowable date range between midnight
+    /// January 1, 0001 CE to 23:59:59.999 on December 31, 9999 CE, with a temporal resolution of
+    /// 1 millisecond. This resolution and range ensures broad support across programming languages
+    /// and guarantees compatibility with RFC 3339.
+    #[serde(rename = "timestamp")]
+    Timestamp(primitive::SmithyTimestamp),
+
+    /// A `byte` is an 8-bit signed integer ranging from -128 to 127 (inclusive).
+    #[serde(rename = "byte")]
+    Byte(primitive::SmithyByte),
+
+    /// A `short` is a 16-bit signed integer ranging from -32,768 to 32,767 (inclusive).
+    #[serde(rename = "short")]
+    Short(primitive::SmithyShort),
+
+    /// An `integer` is a 32-bit signed integer ranging from -2^31 to (2^31)-1 (inclusive).
+    #[serde(rename = "integer")]
+    Integer(primitive::SmithyInteger),
+
+    /// A `long` is a 64-bit signed integer ranging from -2^63 to (2^63)-1 (inclusive).
+    #[serde(rename = "long")]
+    Long(primitive::SmithyLong),
+
+    /// A `float` is a single precision IEEE-754 floating point number.
+    #[serde(rename = "float")]
+    Float(primitive::SmithyFloat),
+
+    /// A `double` is a double precision IEEE-754 floating point number.
+    #[serde(rename = "double")]
+    Double(primitive::SmithyDouble),
 
     /// A `document` represents protocol-agnostic open content that functions as a kind of "any"
     /// type. Document types are represented by a JSON-like data model and can contain UTF-8
@@ -71,15 +81,7 @@ pub enum Shape {
     /// implementation detail of a protocol and MUST NOT have any effect on the types exposed by
     /// tooling to represent a document value.
     #[serde(rename = "document")]
-    Document,
-
-    /// A `timestamp` represents an instant in time in the proleptic Gregorian calendar, independent
-    /// of local times or timezones. Timestamps support an allowable date range between midnight
-    /// January 1, 0001 CE to 23:59:59.999 on December 31, 9999 CE, with a temporal resolution of
-    /// 1 millisecond. This resolution and range ensures broad support across programming languages
-    /// and guarantees compatibility with RFC 3339.
-    #[serde(rename = "timestamp")]
-    Timestamp(primitive::Timestamp),
+    Document(primitive::SmithyDocument),
 
     /// The `enum` shape is used to represent a fixed set of one or more string values. Each value
     /// listed in the enum is a member that implicitly targets the unit type.
@@ -130,9 +132,151 @@ pub enum Shape {
     Resource(Resource),
 }
 
+macro_rules! unwrap_inner {
+    ($self:ident) => {
+        match $self {
+            Self::Unit(u) => u,
+            Self::Blob(b) => b,
+            Self::Boolean(b) => b,
+            Self::String(s) => s,
+            Self::Byte(b) => b,
+            Self::Short(s) => s,
+            Self::Integer(i) => i,
+            Self::Long(l) => l,
+            Self::Float(f) => f,
+            Self::Double(d) => d,
+            Self::BigInteger(b) => b,
+            Self::BigDecimal(b) => b,
+            Self::Document(d) => d,
+            Self::Timestamp(t) => t,
+            Self::Enum(e) => e,
+            Self::IntEnum(i) => i,
+            Self::List(l) => l,
+            Self::Map(m) => m,
+            Self::Structure(s) => s,
+            Self::Union(u) => u,
+            Self::Service(s) => s,
+            Self::Operation(o) => o,
+            Self::Resource(r) => r,
+        }
+    };
+
+    ($self:ident => &mut $($suffix:tt)+) => {
+        match $self {
+            Self::Unit(u) => &mut u.$($suffix)+,
+            Self::Blob(b) => &mut b.$($suffix)+,
+            Self::Boolean(b) => &mut b.$($suffix)+,
+            Self::String(s) => &mut s.$($suffix)+,
+            Self::Byte(b) => &mut b.$($suffix)+,
+            Self::Short(s) => &mut s.$($suffix)+,
+            Self::Integer(i) => &mut i.$($suffix)+,
+            Self::Long(l) => &mut l.$($suffix)+,
+            Self::Float(f) => &mut f.$($suffix)+,
+            Self::Double(d) => &mut d.$($suffix)+,
+            Self::BigInteger(b) => &mut b.$($suffix)+,
+            Self::BigDecimal(b) => &mut b.$($suffix)+,
+            Self::Document(d) => &mut d.$($suffix)+,
+            Self::Timestamp(t) => &mut t.$($suffix)+,
+            Self::Enum(e) => &mut e.$($suffix)+,
+            Self::IntEnum(i) => &mut i.$($suffix)+,
+            Self::List(l) => &mut l.$($suffix)+,
+            Self::Map(m) => &mut m.$($suffix)+,
+            Self::Structure(s) => &mut s.$($suffix)+,
+            Self::Union(u) => &mut u.$($suffix)+,
+            Self::Service(s) => &mut s.$($suffix)+,
+            Self::Operation(o) => &mut o.$($suffix)+,
+            Self::Resource(r) => &mut r.$($suffix)+,
+        }
+    };
+
+    ($self:ident => $($suffix:tt)+) => {
+        match $self {
+            Self::Unit(u) => u.$($suffix)+,
+            Self::Blob(b) => b.$($suffix)+,
+            Self::Boolean(b) => b.$($suffix)+,
+            Self::String(s) => s.$($suffix)+,
+            Self::Byte(b) => b.$($suffix)+,
+            Self::Short(s) => s.$($suffix)+,
+            Self::Integer(i) => i.$($suffix)+,
+            Self::Long(l) => l.$($suffix)+,
+            Self::Float(f) => f.$($suffix)+,
+            Self::Double(d) => d.$($suffix)+,
+            Self::BigInteger(b) => b.$($suffix)+,
+            Self::BigDecimal(b) => b.$($suffix)+,
+            Self::Document(d) => d.$($suffix)+,
+            Self::Timestamp(t) => t.$($suffix)+,
+            Self::Enum(e) => e.$($suffix)+,
+            Self::IntEnum(i) => i.$($suffix)+,
+            Self::List(l) => l.$($suffix)+,
+            Self::Map(m) => m.$($suffix)+,
+            Self::Structure(s) => s.$($suffix)+,
+            Self::Union(u) => u.$($suffix)+,
+            Self::Service(s) => s.$($suffix)+,
+            Self::Operation(o) => o.$($suffix)+,
+            Self::Resource(r) => r.$($suffix)+,
+        }
+    };
+}
+
 impl Shape {
+    /// Returns the inner type as a reference to a `dyn ShapeInfo`.
+    pub fn as_shape_info(&self) -> &dyn ShapeInfo {
+        unwrap_inner!(self)
+    }
+
+    /// Returns the inner type as a mutable reference to a `dyn ShapeInfo`.
+    pub fn as_shape_info_mut(&mut self) -> &mut dyn ShapeInfo {
+        unwrap_inner!(self)
+    }
+}
+
+impl ShapeInfo for Shape {
+    fn resolve(&mut self, smithy_name: &str, model: &SmithyModel) {
+        self.as_shape_info_mut().resolve(smithy_name, model)
+    }
+
+    #[inline(always)]
+    fn smithy_name(&self) -> String {
+        self.as_shape_info().smithy_name()
+    }
+
+    #[inline(always)]
+    fn rust_typename(&self) -> String {
+        self.as_shape_info().rust_typename()
+    }
+
+    #[inline(always)]
+    fn clap_parser(&self) -> Option<String> {
+        self.as_shape_info().clap_parser()
+    }
+
+    #[inline(always)]
+    fn mark_reachable_from_input(&mut self) {
+        self.as_shape_info_mut().mark_reachable_from_input()
+    }
+
+    #[inline(always)]
+    fn derive_builder_validator(&self, var: &str, field_name: &str) -> Option<String> {
+        self.as_shape_info().derive_builder_validator(var, field_name)
+    }
+
+    #[inline(always)]
+    fn generate(&self, w: &mut dyn Write) -> IoResult<()> {
+        self.as_shape_info().generate(w)
+    }
+}
+
+impl Shape {
+    /// If this shape is a list, returns a reference to the underlying list.
+    pub fn as_list(&self) -> Option<&List> {
+        match self {
+            Self::List(l) => Some(l),
+            _ => None,
+        }
+    }
+
     /// If this shape has members, returns a mutable reference to the members map. Otherwise, returns None.
-    pub fn members_mut(&mut self) -> Option<&mut HashMap<String, Member>> {
+    pub fn members_mut(&mut self) -> Option<&mut BTreeMap<String, Member>> {
         match self {
             Self::Enum(e) => Some(&mut e.members),
             Self::IntEnum(i) => Some(&mut i.members),
@@ -143,123 +287,7 @@ impl Shape {
     }
 
     /// If this type has traits, returns a mutable reference to the traits map. Otherwise, returns None.
-    pub fn traits_mut(&mut self) -> Option<&mut HashMap<String, JsonValue>> {
-        match self {
-            Self::Unit(u) => Some(&mut u.traits),
-            Self::Blob(b) => Some(&mut b.traits),
-            Self::Boolean(b) => Some(&mut b.traits),
-            Self::String(s) => Some(&mut s.traits),
-            Self::Byte(b) => Some(&mut b.traits),
-            Self::Short(s) => Some(&mut s.traits),
-            Self::Integer(i) => Some(&mut i.traits),
-            Self::Long(l) => Some(&mut l.traits),
-            Self::Float(f) => Some(&mut f.traits),
-            Self::Double(d) => Some(&mut d.traits),
-            Self::BigInteger(b) => Some(&mut b.traits),
-            Self::BigDecimal(b) => Some(&mut b.traits),
-            Self::Document => None,
-            Self::Timestamp(t) => Some(&mut t.traits),
-            Self::Enum(e) => Some(&mut e.traits),
-            Self::IntEnum(i) => Some(&mut i.traits),
-            Self::List(l) => Some(&mut l.traits),
-            Self::Map(m) => Some(&mut m.traits),
-            Self::Structure(s) => Some(&mut s.traits),
-            Self::Union(u) => Some(&mut u.traits),
-            _ => None,
-        }
-    }
-
-    /// Returns the inner typed shape; panics if the inner type is not a [`Typed`] shape.
-    pub fn inner(&self) -> Option<&dyn Typed> {
-        match self {
-            Self::Unit(u) => Some(u),
-            Self::Blob(b) => Some(b),
-            Self::Boolean(b) => Some(b),
-            Self::String(s) => Some(s),
-            Self::Byte(b) => Some(b),
-            Self::Short(s) => Some(s),
-            Self::Integer(i) => Some(i),
-            Self::Long(l) => Some(l),
-            Self::Float(f) => Some(f),
-            Self::Double(d) => Some(d),
-            Self::BigInteger(b) => Some(b),
-            Self::BigDecimal(b) => Some(b),
-            Self::Document => unimplemented!("Document type is not supported yet"),
-            Self::Timestamp(t) => Some(t),
-            Self::Enum(e) => Some(e),
-            Self::IntEnum(i) => Some(i),
-            Self::List(l) => Some(l),
-            Self::Map(m) => Some(m),
-            Self::Structure(s) => Some(s),
-            Self::Union(u) => Some(u),
-            _ => None,
-        }
-    }
-
-    /// Returns the inner typed shape as mutable; panics if the inner type is not a [`Typed`] shape.
-    pub fn inner_mut(&mut self) -> Option<&mut dyn Typed> {
-        match self {
-            Self::Unit(u) => Some(u),
-            Self::Blob(b) => Some(b),
-            Self::Boolean(b) => Some(b),
-            Self::String(s) => Some(s),
-            Self::Byte(b) => Some(b),
-            Self::Short(s) => Some(s),
-            Self::Integer(i) => Some(i),
-            Self::Long(l) => Some(l),
-            Self::Float(f) => Some(f),
-            Self::Double(d) => Some(d),
-            Self::BigInteger(b) => Some(b),
-            Self::BigDecimal(b) => Some(b),
-            Self::Document => unimplemented!("Document type is not supported yet"),
-            Self::Timestamp(t) => Some(t),
-            Self::Enum(e) => Some(e),
-            Self::IntEnum(i) => Some(i),
-            Self::List(l) => Some(l),
-            Self::Map(m) => Some(m),
-            Self::Structure(s) => Some(s),
-            Self::Union(u) => Some(u),
-            _ => None,
-        }
-    }
-}
-
-impl Typed for Shape {
-    fn rust_typename(&self) -> String {
-        self.inner().expect("Shape does not contain a typed inner shape").rust_typename()
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        if let Some(inner) = self.inner() {
-            inner.write(output)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn has_decl(&self, model: &super::SmithyModel) -> bool {
-        if let Some(inner) = self.inner() {
-            inner.has_decl(model)
-        } else {
-            false
-        }
-    }
-
-    fn is_primitive(&self) -> bool {
-        self.inner().expect("Shape does not contain a typed inner shape").is_primitive()
-    }
-
-    fn get_clap_parser(&self) -> String {
-        self.inner().expect("Shape does not contain a typed inner shape").get_clap_parser()
-    }
-
-    fn get_derive_builder_validator(&self, var: &str) -> Option<String> {
-        self.inner().expect("Shape does not contain a typed inner shape").get_derive_builder_validator(var)
-    }
-
-    fn mark_reachable_from_input(&mut self) {
-        if let Some(inner) = self.inner_mut() {
-            inner.mark_reachable_from_input();
-        }
+    pub fn traits_mut(&mut self) -> &mut TraitMap {
+        unwrap_inner!(self => &mut base.traits)
     }
 }

--- a/scratchstack-shapegen/src/shape_base.rs
+++ b/scratchstack-shapegen/src/shape_base.rs
@@ -1,0 +1,58 @@
+use {
+    crate::{StrExt as _, TraitMap},
+    serde::{Deserialize, Serialize},
+    std::io::{Result as IoResult, Write},
+};
+
+/// Basic features of a shape.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ShapeBase {
+    /// The Smithy name of the shape.
+    ///
+    /// This is resolved during a call to `SmithyModel::resolve`.
+    #[serde(skip)]
+    pub smithy_name: Option<String>,
+
+    /// The Rust type name of the shape.
+    ///
+    /// This is resolved during a call to `SmithyModel::resolve`.
+    #[serde(skip)]
+    pub rust_typename: Option<String>,
+
+    /// Traits associated with the shape.
+    #[serde(default)]
+    pub traits: TraitMap,
+}
+
+impl ShapeBase {
+    /// Resolves the stored names of this shape, panicking if they are already set.
+    pub fn resolve(&mut self, smithy_name: &str) {
+        assert!(self.smithy_name.is_none());
+        assert!(self.rust_typename.is_none());
+
+        let hash_pos = smithy_name.find('#').unwrap();
+        let simple_typename = &smithy_name[hash_pos + 1..];
+        let rust_typename = simple_typename.to_pascal_case();
+
+        self.smithy_name = Some(smithy_name.to_string());
+        self.rust_typename = Some(rust_typename);
+    }
+
+    /// Returns the Smithy name of this shape, panicking if it is not set.
+    #[inline(always)]
+    pub fn smithy_name(&self) -> String {
+        self.smithy_name.clone().expect("ShapeBase should have a Smithy name after resolution")
+    }
+
+    /// Returns the Rust typename of this shape, panicking if it is not set.
+    #[inline(always)]
+    pub fn rust_typename(&self) -> String {
+        self.rust_typename.clone().expect("ShapeBase should have a Rust typename after resolution")
+    }
+
+    /// Writes documentation for this shape to the provided writer.
+    #[inline(always)]
+    pub fn write_docs(&self, writer: &mut impl Write, indent: &str) -> IoResult<()> {
+        self.traits.write_docs(writer, indent)
+    }
+}

--- a/scratchstack-shapegen/src/smithy_model.rs
+++ b/scratchstack-shapegen/src/smithy_model.rs
@@ -1,10 +1,10 @@
 use {
-    super::{Shape, Typed, to_pascal_case},
+    crate::{Shape, ShapeInfo as _, primitive::SmithyUnit},
     serde::{Deserialize, Serialize},
     serde_json::Value,
     std::{
         cell::RefCell,
-        collections::HashMap,
+        collections::BTreeMap,
         io::{Result as IoResult, Write},
         rc::Rc,
     },
@@ -19,161 +19,204 @@ pub struct SmithyModel {
 
     /// Defines all of the metadata about the model using a JSON object. Each key is the metadata
     /// key to set, and each value is the metadata value to assign to the key.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub metadata: HashMap<String, Value>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub metadata: BTreeMap<String, Value>,
 
     /// A map of absolute shape IDs to shape definitions.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub shapes: HashMap<String, Rc<RefCell<Shape>>>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub shapes: BTreeMap<String, Rc<RefCell<Shape>>>,
 }
 
 impl SmithyModel {
+    /// Adds default shapes to the model if they do not already exist.
+    pub fn add_default_shapes(&mut self) {
+        self.shapes.entry("smithy.api#Unit".to_string()).or_insert_with(|| {
+            let unit = SmithyUnit::new("smithy.api#Unit");
+            Rc::new(RefCell::new(Shape::Unit(unit)))
+        });
+    }
+
     /// Resolve all shapes in the model by calling `resolve` on each shape until all shapes are resolved.
     pub fn resolve(&self) {
         for (shape_name, shape) in &self.shapes {
-            let mut shape = shape.borrow_mut();
-            let hash_pos = shape_name.find('#').expect("Shape ID should contain a '#' character");
-            let simple_typename = &shape_name[hash_pos + 1..];
-            let rust_typename = to_pascal_case(simple_typename);
-
-            match &mut *shape {
-                Shape::Unit(u) => {
-                    assert!(u.smithy_typename.is_none());
-                    assert!(u.rust_typename.is_none());
-                    u.smithy_typename = Some(shape_name.clone());
-                    u.rust_typename = Some(rust_typename);
-                }
-                Shape::Blob(b) => {
-                    assert!(b.smithy_typename.is_none());
-                    assert!(b.rust_typename.is_none());
-                    b.smithy_typename = Some(shape_name.clone());
-                    b.rust_typename = Some(rust_typename);
-                }
-                Shape::Boolean(b) => {
-                    assert!(b.smithy_typename.is_none());
-                    assert!(b.rust_typename.is_none());
-                    b.smithy_typename = Some(shape_name.clone());
-                    b.rust_typename = Some(rust_typename);
-                }
-                Shape::String(s) => {
-                    assert!(s.smithy_typename.is_none());
-                    assert!(s.rust_typename.is_none());
-                    s.smithy_typename = Some(shape_name.clone());
-                    s.rust_typename = Some(rust_typename);
-                }
-                Shape::Byte(b) => {
-                    assert!(b.smithy_typename.is_none());
-                    assert!(b.rust_typename.is_none());
-                    b.smithy_typename = Some(shape_name.clone());
-                    b.rust_typename = Some(rust_typename);
-                }
-                Shape::Short(s) => {
-                    assert!(s.smithy_typename.is_none());
-                    assert!(s.rust_typename.is_none());
-                    s.smithy_typename = Some(shape_name.clone());
-                    s.rust_typename = Some(rust_typename);
-                }
-                Shape::Integer(i) => {
-                    assert!(i.smithy_typename.is_none());
-                    assert!(i.rust_typename.is_none());
-                    i.smithy_typename = Some(shape_name.clone());
-                    i.rust_typename = Some(rust_typename);
-                }
-                Shape::Long(l) => {
-                    assert!(l.smithy_typename.is_none());
-                    assert!(l.rust_typename.is_none());
-                    l.smithy_typename = Some(shape_name.clone());
-                    l.rust_typename = Some(rust_typename);
-                }
-                Shape::Float(f) => {
-                    assert!(f.smithy_typename.is_none());
-                    assert!(f.rust_typename.is_none());
-                    f.smithy_typename = Some(shape_name.clone());
-                    f.rust_typename = Some(rust_typename);
-                }
-                Shape::Double(d) => {
-                    assert!(d.smithy_typename.is_none());
-                    assert!(d.rust_typename.is_none());
-                    d.smithy_typename = Some(shape_name.clone());
-                    d.rust_typename = Some(rust_typename);
-                }
-                Shape::BigInteger(b) => {
-                    assert!(b.smithy_typename.is_none());
-                    assert!(b.rust_typename.is_none());
-                    b.smithy_typename = Some(shape_name.clone());
-                    b.rust_typename = Some(rust_typename);
-                }
-                Shape::BigDecimal(b) => {
-                    assert!(b.smithy_typename.is_none());
-                    assert!(b.rust_typename.is_none());
-                    b.smithy_typename = Some(shape_name.clone());
-                    b.rust_typename = Some(rust_typename);
-                }
-                Shape::Document => {
-                    unimplemented!("Document type is not supported yet");
-                }
-                Shape::Timestamp(t) => {
-                    assert!(t.smithy_typename.is_none());
-                    assert!(t.rust_typename.is_none());
-                    t.smithy_typename = Some(shape_name.clone());
-                    t.rust_typename = Some(rust_typename);
-                }
-                Shape::Enum(e) => {
-                    assert!(e.smithy_typename.is_none());
-                    assert!(e.rust_typename.is_none());
-                    e.smithy_typename = Some(shape_name.clone());
-                    e.rust_typename = Some(rust_typename);
-                }
-                Shape::IntEnum(e) => {
-                    assert!(e.smithy_typename.is_none());
-                    assert!(e.rust_typename.is_none());
-                    e.smithy_typename = Some(shape_name.clone());
-                    e.rust_typename = Some(rust_typename);
-                }
-                Shape::List(l) => {
-                    let member_shape =
-                        self.shapes.get(&l.member.target).expect("List member should exist in model").clone();
-                    l.member.shape = Some(member_shape);
-                }
-                Shape::Map(m) => {
-                    let key_shape = self.shapes.get(&m.key.target).expect("Map key should exist in model").clone();
-                    let value_shape =
-                        self.shapes.get(&m.value.target).expect("Map value should exist in model").clone();
-                    m.key.shape = Some(key_shape);
-                    m.value.shape = Some(value_shape);
-                }
-                Shape::Structure(s) => {
-                    assert!(s.smithy_typename.is_none());
-                    assert!(s.rust_typename.is_none());
-                    s.smithy_typename = Some(shape_name.clone());
-                    s.rust_typename = Some(rust_typename);
-
-                    for member in &mut s.members.values_mut() {
-                        let member_shape =
-                            self.shapes.get(&member.target).expect("Structure member should exist in model").clone();
-                        member.shape = Some(member_shape);
-                    }
-                }
-                Shape::Union(u) => {
-                    assert!(u.smithy_typename.is_none());
-                    assert!(u.rust_typename.is_none());
-                    u.smithy_typename = Some(shape_name.clone());
-                    u.rust_typename = Some(rust_typename);
-                }
-                _ => {}
+            if shape_name.starts_with("smithy.api#") {
+                continue;
             }
+
+            let mut shape = shape.borrow_mut();
+            shape.resolve(shape_name, self);
         }
 
         // Mark all input structures as reachable from the input.
         for shape in self.shapes.values() {
             let mut shape = shape.borrow_mut();
             if let Shape::Structure(s) = &mut *shape
-                && s.traits.contains_key("smithy.api#input")
+                && s.base.traits.is_input()
             {
                 s.mark_reachable_from_input();
             }
         }
     }
+
+    //         let hash_pos = shape_name.find('#').expect("Shape ID should contain a '#' character");
+    //         let simple_typename = &shape_name[hash_pos + 1..];
+    //         let rust_typename = simple_typename.to_pascal_case();
+
+    //         match &mut *shape {
+    //             Shape::Unit(u) => {
+    //                 assert!(u.smithy_typename.is_none());
+    //                 assert!(u.rust_typename.is_none());
+    //                 u.smithy_typename = Some(shape_name.clone());
+    //                 u.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Blob(b) => {
+    //                 assert!(b.smithy_typename.is_none());
+    //                 assert!(b.rust_typename.is_none());
+    //                 b.smithy_typename = Some(shape_name.clone());
+    //                 b.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Boolean(b) => {
+    //                 assert!(b.smithy_typename.is_none());
+    //                 assert!(b.rust_typename.is_none());
+    //                 b.smithy_typename = Some(shape_name.clone());
+    //                 b.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::String(s) => {
+    //                 assert!(s.smithy_typename.is_none());
+    //                 assert!(s.rust_typename.is_none());
+    //                 s.smithy_typename = Some(shape_name.clone());
+    //                 s.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Byte(b) => {
+    //                 assert!(b.smithy_typename.is_none());
+    //                 assert!(b.rust_typename.is_none());
+    //                 b.smithy_typename = Some(shape_name.clone());
+    //                 b.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Short(s) => {
+    //                 assert!(s.smithy_typename.is_none());
+    //                 assert!(s.rust_typename.is_none());
+    //                 s.smithy_typename = Some(shape_name.clone());
+    //                 s.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Integer(i) => {
+    //                 assert!(i.smithy_typename.is_none());
+    //                 assert!(i.rust_typename.is_none());
+    //                 i.smithy_typename = Some(shape_name.clone());
+    //                 i.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Long(l) => {
+    //                 assert!(l.smithy_typename.is_none());
+    //                 assert!(l.rust_typename.is_none());
+    //                 l.smithy_typename = Some(shape_name.clone());
+    //                 l.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Float(f) => {
+    //                 assert!(f.smithy_typename.is_none());
+    //                 assert!(f.rust_typename.is_none());
+    //                 f.smithy_typename = Some(shape_name.clone());
+    //                 f.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Double(d) => {
+    //                 assert!(d.smithy_typename.is_none());
+    //                 assert!(d.rust_typename.is_none());
+    //                 d.smithy_typename = Some(shape_name.clone());
+    //                 d.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::BigInteger(b) => {
+    //                 assert!(b.smithy_typename.is_none());
+    //                 assert!(b.rust_typename.is_none());
+    //                 b.smithy_typename = Some(shape_name.clone());
+    //                 b.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::BigDecimal(b) => {
+    //                 assert!(b.smithy_typename.is_none());
+    //                 assert!(b.rust_typename.is_none());
+    //                 b.smithy_typename = Some(shape_name.clone());
+    //                 b.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Document(_) => {
+    //                 unimplemented!("Document type is not supported yet");
+    //             }
+    //             Shape::Timestamp(t) => {
+    //                 assert!(t.smithy_typename.is_none());
+    //                 assert!(t.rust_typename.is_none());
+    //                 t.smithy_typename = Some(shape_name.clone());
+    //                 t.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Enum(e) => {
+    //                 assert!(e.smithy_typename.is_none());
+    //                 assert!(e.rust_typename.is_none());
+    //                 e.smithy_typename = Some(shape_name.clone());
+    //                 e.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::IntEnum(e) => {
+    //                 assert!(e.smithy_typename.is_none());
+    //                 assert!(e.rust_typename.is_none());
+    //                 e.smithy_typename = Some(shape_name.clone());
+    //                 e.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::List(l) => {
+    //                 let member_shape =
+    //                     self.shapes.get(&l.member.target).expect("List member should exist in model").clone();
+    //                 l.member.shape = Some(member_shape);
+    //             }
+    //             Shape::Map(m) => {
+    //                 let key_shape = self.shapes.get(&m.key.target).expect("Map key should exist in model").clone();
+    //                 let value_shape =
+    //                     self.shapes.get(&m.value.target).expect("Map value should exist in model").clone();
+    //                 m.key.shape = Some(key_shape);
+    //                 m.value.shape = Some(value_shape);
+    //             }
+    //             Shape::Structure(s) => {
+    //                 assert!(s.smithy_typename.is_none());
+    //                 assert!(s.rust_typename.is_none());
+    //                 s.smithy_typename = Some(shape_name.clone());
+    //                 s.rust_typename = Some(rust_typename);
+
+    //                 for member in &mut s.members.values_mut() {
+    //                     let member_shape =
+    //                         self.shapes.get(&member.target).expect("Structure member should exist in model").clone();
+    //                     member.shape = Some(member_shape);
+    //                 }
+    //             }
+    //             Shape::Union(u) => {
+    //                 assert!(u.smithy_typename.is_none());
+    //                 assert!(u.rust_typename.is_none());
+    //                 u.smithy_typename = Some(shape_name.clone());
+    //                 u.rust_typename = Some(rust_typename);
+    //             }
+    //             Shape::Operation(o) => {
+    //                 assert!(o.smithy_name.is_none());
+    //                 assert!(o.rust_typename.is_none());
+    //                 assert!(o.input_shape.is_none());
+    //                 assert!(o.output_shape.is_none());
+    //                 assert!(o.error_shapes.is_empty());
+
+    //                 let Some(input_target) = self.shapes.get(&o.input.target) else {
+    //                     panic!("Input shape {} should exist in model", o.input.target);
+    //                 };
+    //                 let Some(output_target) = self.shapes.get(&o.output.target) else {
+    //                     panic!("Output shape {} should exist in model", o.output.target);
+    //                 };
+
+    //                 o.smithy_name = Some(shape_name.clone());
+    //                 o.rust_typename = Some(rust_typename);
+    //                 o.input_shape = Some(input_target.clone());
+    //                 o.output_shape = Some(output_target.clone());
+    //                 o.error_shapes = o
+    //                     .errors
+    //                     .iter()
+    //                     .filter_map(|r| {
+    //                         Some(self.shapes.get(&r.target).expect("Error shape should exist in model").clone())
+    //                     })
+    //                     .collect();
+    //             }
+    //             _ => {}
+    //         }
+    //     }
+
+    // }
 
     /// Gets a shape by its shape ID.
     pub fn get_shape(&self, shape_id: &str) -> Option<Rc<RefCell<Shape>>> {
@@ -183,7 +226,7 @@ impl SmithyModel {
     /// Generates Rust code for the Smithy model.
     pub fn generate(&self, writer: &mut impl Write) -> IoResult<()> {
         for shape in self.shapes.values() {
-            shape.borrow().write(writer)?;
+            shape.borrow().generate(writer)?;
         }
         Ok(())
     }

--- a/scratchstack-shapegen/src/str_ext.rs
+++ b/scratchstack-shapegen/src/str_ext.rs
@@ -1,0 +1,113 @@
+//! Extensions on string types.
+
+/// Rust keywords that cannot be used as identifiers. These are used to determine when to use raw
+/// identifiers in the generated code.
+const RUST_IDENTS: &[&str] = &[
+    "abstract", "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern",
+    "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
+    "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe", "use", "where", "while",
+];
+
+pub trait StrExt {
+    /// Indicates whether this Smithy identifier is a builtin type.
+    fn is_smithy_builtin(&self) -> bool;
+
+    /// Indicates whether this string is in SCREAMING_SNAKE_CASE.
+    fn is_screaming_snake_case(&self) -> bool;
+
+    /// Convert an identifier to Pascal case.
+    ///
+    /// This is used to convert Smithy shape names to Rust type names.
+    fn to_pascal_case(&self) -> String;
+
+    /// Convert a string identifier to snake case. This is used to convert Smithy member names to Rust field names.
+    fn to_snake_case(&self) -> String;
+}
+
+impl StrExt for str {
+    fn is_smithy_builtin(&self) -> bool {
+        self.starts_with("smithy.api#")
+    }
+
+    fn is_screaming_snake_case(&self) -> bool {
+        self.chars().all(|c| c.is_ascii_uppercase() || c == '_')
+    }
+
+    fn to_pascal_case(&self) -> String {
+        let mut result = String::new();
+        let mut capitalize_next = true;
+
+        if self.is_screaming_snake_case() {
+            // Change SCREAMING_SNAKE_CASE to ScreamingSnakeCase.
+            for c in self.chars() {
+                if c == '_' {
+                    capitalize_next = true;
+                } else if capitalize_next {
+                    result.push(c.to_ascii_uppercase());
+                    capitalize_next = false;
+                } else {
+                    result.push(c.to_ascii_lowercase());
+                }
+            }
+        } else {
+            for c in self.chars() {
+                if c == '_' {
+                    capitalize_next = true;
+                } else if capitalize_next {
+                    result.push(c.to_ascii_uppercase());
+                    capitalize_next = false;
+                } else {
+                    result.push(c);
+                }
+            }
+        }
+
+        if RUST_IDENTS.contains(&result.as_str()) {
+            result = format!("r#{result}");
+        }
+
+        result
+    }
+
+    fn to_snake_case(&self) -> String {
+        let mut result = String::new();
+        let mut prev_char_was_uppercase = false;
+
+        for (i, c) in self.chars().enumerate() {
+            if c.is_uppercase() {
+                if i > 0 && !prev_char_was_uppercase {
+                    result.push('_');
+                }
+                result.push(c.to_ascii_lowercase());
+                prev_char_was_uppercase = true;
+            } else {
+                result.push(c);
+                prev_char_was_uppercase = false;
+            }
+        }
+
+        if RUST_IDENTS.contains(&result.as_str()) {
+            result = format!("r#{result}");
+        }
+
+        result
+    }
+}
+
+impl StrExt for String {
+    fn is_smithy_builtin(&self) -> bool {
+        self.as_str().is_smithy_builtin()
+    }
+
+    fn is_screaming_snake_case(&self) -> bool {
+        self.as_str().is_screaming_snake_case()
+    }
+
+    fn to_pascal_case(&self) -> String {
+        self.as_str().to_pascal_case()
+    }
+
+    fn to_snake_case(&self) -> String {
+        self.as_str().to_snake_case()
+    }
+}

--- a/scratchstack-shapegen/src/structure.rs
+++ b/scratchstack-shapegen/src/structure.rs
@@ -1,9 +1,8 @@
 use {
-    super::{Member, Typed, to_snake_case},
+    super::{Member, ShapeBase, ShapeInfo, SmithyModel, StrExt},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::{
-        collections::HashMap,
+        collections::BTreeMap,
         io::{Result as IoResult, Write},
     },
 };
@@ -13,17 +12,13 @@ use {
 /// member definition.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Structure {
-    /// The name of this structure in the Smithy model.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub smithy_typename: Option<String>,
+    /// Basic shape information for the `structure` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
 
-    /// The Rust name of this structure.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub rust_typename: Option<String>,
+    /// The members of the structure. Each member name maps to exactly one member definition.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub members: BTreeMap<String, Member>,
 
     /// Whether this struct is reachable from an API input shape. This is used to determine
     /// whether to generate Clap parsers for this struct.
@@ -31,32 +26,74 @@ pub struct Structure {
     /// This is resolved during a call to `SmithyModel::resolve`.
     #[serde(skip, default)]
     pub reachable_from_input: bool,
+}
 
-    /// The members of the structure. Each member name maps to exactly one member definition.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub members: HashMap<String, Member>,
+impl ShapeInfo for Structure {
+    fn smithy_name(&self) -> String {
+        self.base.smithy_name()
+    }
 
-    /// Traits to apply to the type.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
+    fn rust_typename(&self) -> String {
+        self.base.rust_typename()
+    }
+
+    fn resolve(&mut self, shape_name: &str, model: &SmithyModel) {
+        self.base.resolve(shape_name);
+        for member in self.members.values_mut() {
+            member.resolve(shape_name, model);
+        }
+    }
+
+    /// Returns the Clap parser for this structure, if it is reachable from an API input shape.
+    fn clap_parser(&self) -> Option<String> {
+        // TODO: Do we need this, or can it be elided? Or do we need shorthand magic?
+        let typename = self.rust_typename();
+        Some(format!("{typename}::from_str"))
+    }
+
+    fn mark_reachable_from_input(&mut self) {
+        if self.reachable_from_input {
+            return;
+        }
+
+        self.reachable_from_input = true;
+
+        self.members.values_mut().for_each(|member| {
+            member.mark_reachable_from_input();
+        });
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        self.write_rust_decl(output)?;
+        self.write_rust_impl(output)?;
+        if self.reachable_from_input {
+            self.write_rust_from_str_impl(output)?;
+            self.write_rust_try_from_shorthand_value_impl(output)?;
+        }
+
+        if self.base.traits.is_aws_query_error() {
+            self.write_rust_aws_query_error_impl(output)?;
+        }
+
+        self.write_builder_validate(output)?;
+        Ok(())
+    }
 }
 
 impl Structure {
     /// Writes the Rust declaration for the main body of this structure.
     fn write_rust_decl(&self, output: &mut dyn Write) -> IoResult<()> {
         let rust_typename = self.rust_typename();
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
+        let is_error = self.base.traits.is_error();
 
-        writeln!(output, "#[derive(Builder, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]")?;
-        writeln!(output, "#[builder(pattern = \"owned\", build_fn(validate = \"Self::validate\"))]")?;
+        // Write the documentation comments for the structure, if any.
+        self.base.traits.write_docs(output, "")?;
 
+        // Attributes for the structure.
+        writeln!(output, "#[derive(::derive_builder::Builder)]")?;
+        writeln!(output, "#[derive(::std::clone::Clone, ::std::cmp::Eq, ::std::cmp::PartialEq, ::std::fmt::Debug)]")?;
+        writeln!(output, "#[derive(::serde::Deserialize, ::serde::Serialize)]")?;
+        writeln!(output, "#[builder(pattern = \"owned\", build_fn(validate = \"Self::validate\"), setter(into))]")?;
         if self.reachable_from_input {
             writeln!(output, "#[cfg_attr(feature = \"clap\", derive(::clap::Parser))]")?;
         }
@@ -71,27 +108,19 @@ impl Structure {
                 is_first = false;
             }
 
-            let docs = member.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-            if let Some(docs) = docs {
-                for line in docs.lines() {
-                    writeln!(output, "    /// {}", line.trim())?;
-                }
-            } else {
-                writeln!(output, "    #[allow(missing_docs)]")?;
-            }
-
-            let is_optional = member.is_optional();
+            member.traits.write_docs(output, "    ")?;
+            let is_optional = !member.traits.is_required();
             let is_list = member.is_list();
             if self.reachable_from_input {
                 let mut clap_args = vec!["long".to_string()];
-                // Always use the non-optional parser: Clap automatically produces None for
-                // Option<T> fields and an empty Vec for list fields when the arg is absent.
-                clap_args.push(format!("value_parser = {}", member.get_clap_parser()));
+                if let Some(clap_parser) = member.clap_parser() {
+                    clap_args.push(format!("value_parser = {clap_parser}"))
+                }
                 writeln!(output, "    #[cfg_attr(feature = \"clap\", clap({}))]", clap_args.join(", "))?;
             }
 
             let mut member_type = member.rust_typename();
-            let rust_member_name = to_snake_case(member_name);
+            let rust_member_name = member_name.to_snake_case();
 
             if is_optional && !is_list {
                 member_type = format!("Option<{}>", member_type);
@@ -102,6 +131,14 @@ impl Structure {
                 writeln!(output, "    #[builder(default)]")?;
             }
             writeln!(output, "    pub {rust_member_name}: {member_type},")?;
+        }
+
+        // If this is an error type, add metadata to the structure for error handling.
+        if is_error {
+            writeln!(output)?;
+            writeln!(output, "    /// Metadata about the error")?;
+            writeln!(output, "    #[serde(skip)]")?;
+            writeln!(output, "    pub meta: ::aws_smithy_types::error::ErrorMetadata,")?;
         }
 
         writeln!(output, "}}")?;
@@ -133,7 +170,7 @@ impl Structure {
         writeln!(output, "    fn from_str(s: &str) -> Result<Self, Self::Err> {{")?;
         writeln!(
             output,
-            "        let value = crate::shorthand::parse(s).map_err(|e| format!(\"Failed to parse {rust_typename} from '{{s}}': {{e}}\"))?;"
+            "        let value = ::scratchstack_cli_utils::parse_shorthand(s).map_err(|e| format!(\"Failed to parse {rust_typename} from '{{s}}': {{e}}\"))?;"
         )?;
         writeln!(
             output,
@@ -144,10 +181,14 @@ impl Structure {
             writeln!(output, "        let mut builder = {rust_typename}Builder::default();")?;
             writeln!(output, "        for (key, value) in map {{")?;
             writeln!(output, "            match key.as_str() {{")?;
-            for member_name in self.members.keys() {
-                let rust_member_name = to_snake_case(member_name);
+            for (member_name, member) in self.members.iter() {
+                let rust_member_name = member_name.to_snake_case();
+                let rust_member_type = member.rust_typename();
                 writeln!(output, "                \"{member_name}\" => {{")?;
-                writeln!(output, "                    builder = builder.{rust_member_name}(value.try_into()?);")?;
+                writeln!(
+                    output,
+                    "                    builder = builder.{rust_member_name}(::std::convert::TryInto::<{rust_member_type}>::try_into(value)?);"
+                )?;
                 writeln!(output, "                }}")?;
             }
             writeln!(
@@ -175,12 +216,20 @@ impl Structure {
         Ok(())
     }
 
+    /// Write a rust implemenation of `TryFrom<&ShorthandValue>` for this structure.
+    ///
+    /// This allows the structure to be created from a `ShorthandValue`, used to parse parameters
+    /// provided on the CLI in a shorthand format, e.g. `--tag Key=key,Value=value` instead of the
+    /// more verbose JSON syntax `--tag [{"Key":"key","Value":"value"}]`.
     fn write_rust_try_from_shorthand_value_impl(&self, output: &mut dyn Write) -> IoResult<()> {
         let rust_typename = self.rust_typename();
         writeln!(output, "#[cfg(feature = \"clap\")]")?;
-        writeln!(output, "impl TryFrom<&crate::shorthand::Value> for {rust_typename} {{")?;
+        writeln!(output, "impl TryFrom<&::scratchstack_cli_utils::ShorthandValue> for {rust_typename} {{")?;
         writeln!(output, "    type Error = String;")?;
-        writeln!(output, "    fn try_from(value: &crate::shorthand::Value) -> Result<Self, Self::Error> {{")?;
+        writeln!(
+            output,
+            "    fn try_from(value: &::scratchstack_cli_utils::ShorthandValue) -> Result<Self, Self::Error> {{"
+        )?;
         writeln!(
             output,
             "        let map = value.as_map().ok_or(format!(\"Expected a map/object to convert to {rust_typename}, but got '{{value:?}}'\"))?;"
@@ -190,10 +239,14 @@ impl Structure {
             writeln!(output, "        let mut builder = {rust_typename}Builder::default();")?;
             writeln!(output, "        for (key, value) in map {{")?;
             writeln!(output, "            match key.as_str() {{")?;
-            for member_name in self.members.keys() {
-                let rust_member_name = to_snake_case(member_name);
+            for (member_name, member) in self.members.iter() {
+                let rust_member_name = member_name.to_snake_case();
+                let rust_member_type = member.rust_typename();
                 writeln!(output, "                \"{member_name}\" => {{")?;
-                writeln!(output, "                    builder = builder.{rust_member_name}(value.try_into()?);")?;
+                writeln!(
+                    output,
+                    "                    builder = builder.{rust_member_name}(::std::convert::TryInto::<{rust_member_type}>::try_into(value)?);"
+                )?;
                 writeln!(output, "                }}")?;
             }
             writeln!(
@@ -222,17 +275,75 @@ impl Structure {
         Ok(())
     }
 
+    /// Writes implementations of the `Error`, `Display`, `RequestId`, `ProvideErrorKind`, and
+    /// `ProvideErrorMetadata` traits for this structure.
+    fn write_rust_aws_query_error_impl(&self, output: &mut dyn Write) -> IoResult<()> {
+        let rust_typename = self.rust_typename();
+        let qe_any = self.base.traits.aws_query_error().unwrap();
+        let qe_map = qe_any.as_object().unwrap();
+        let code = qe_map.get("code").unwrap().as_str().unwrap();
+        let error_type = self.base.traits.error().unwrap();
+
+        writeln!(output, "impl ::std::fmt::Display for {rust_typename} {{")?;
+        writeln!(output, "    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {{")?;
+        writeln!(output, "        f.write_str(\"{rust_typename}\")?;")?;
+        writeln!(output, "        if let ::std::option::Option::Some(message) = &self.message {{")?;
+        writeln!(output, "            ::std::write!(f, \": {{message}}\")?;")?;
+        writeln!(output, "        }}")?;
+        writeln!(output, "        ::std::result::Result::Ok(())")?;
+        writeln!(output, "    }}")?;
+        writeln!(output, "}}")?;
+        writeln!(output)?;
+        writeln!(output, "impl ::std::error::Error for {rust_typename} {{}}")?;
+        writeln!(output)?;
+        writeln!(output, "impl ::aws_types::request_id::RequestId for {rust_typename} {{")?;
+        writeln!(output, "    #[inline(always)]")?;
+        writeln!(output, "    fn request_id(&self) -> ::std::option::Option<&str> {{")?;
+        writeln!(output, "        ::aws_smithy_types::error::metadata::ProvideErrorMetadata::meta(self).request_id()")?;
+        writeln!(output, "    }}")?;
+        writeln!(output, "}}")?;
+
+        writeln!(output)?;
+        writeln!(output, "impl ::aws_smithy_types::retry::ProvideErrorKind for {rust_typename} {{")?;
+        writeln!(output, "    #[inline(always)]")?;
+        writeln!(
+            output,
+            "    fn retryable_error_kind(&self) -> ::std::option::Option<::aws_smithy_types::retry::ErrorKind> {{"
+        )?;
+        if error_type == "client" {
+            writeln!(output, "        ::std::option::Option::Some(::aws_smithy_types::retry::ErrorKind::ClientError)")?;
+        } else {
+            writeln!(output, "        ::std::option::Option::Some(::aws_smithy_types::retry::ErrorKind::ServerError)")?;
+        }
+        writeln!(output, "    }}")?;
+        writeln!(output)?;
+        writeln!(output, "    #[inline(always)]")?;
+        writeln!(output, "    fn code(&self) -> ::std::option::Option<&str> {{")?;
+        writeln!(output, "        ::std::option::Option::Some(\"{code}\")")?;
+        writeln!(output, "    }}")?;
+        writeln!(output, "}}")?;
+        writeln!(output)?;
+        writeln!(output, "impl ::aws_smithy_types::error::metadata::ProvideErrorMetadata for {rust_typename} {{")?;
+        writeln!(output, "    #[inline(always)]")?;
+        writeln!(output, "    fn meta(&self) -> &::aws_smithy_types::error::metadata::ErrorMetadata {{")?;
+        writeln!(output, "        &self.meta")?;
+        writeln!(output, "    }}")?;
+        writeln!(output, "}}")?;
+
+        Ok(())
+    }
+
     fn write_builder_validate(&self, output: &mut dyn Write) -> IoResult<()> {
         let rust_typename = self.rust_typename();
         writeln!(output, "impl {rust_typename}Builder {{")?;
         writeln!(output, "    #[allow(clippy::collapsible_if)]")?;
         writeln!(output, "    fn validate(&self) -> Result<(), String> {{")?;
         for (member_name, member) in &self.members {
-            let rust_member_name = to_snake_case(member_name);
-            let is_optional = member.is_optional();
+            let rust_member_name = member_name.to_snake_case();
+            let is_required = member.is_required();
             let is_list = member.is_list();
 
-            if !is_optional && !is_list {
+            if is_required && !is_list {
                 writeln!(output, "        if self.{rust_member_name}.is_none() {{")?;
                 writeln!(
                     output,
@@ -241,20 +352,20 @@ impl Structure {
                 writeln!(output, "        }}")?;
             }
 
-            let member_validator = member.get_derive_builder_validator("value");
+            let member_validator = member.derive_builder_validator("value", &rust_typename);
             if let Some(mut validator) = member_validator
                 && !validator.trim().is_empty()
             {
                 validator = validator.trim().replace("\n", "\n            ");
-                if is_optional {
+                if is_required || is_list {
+                    writeln!(output, "        if let Some(value) = &self.{rust_member_name} {{")?;
+                    writeln!(output, "            {validator}")?;
+                    writeln!(output, "        }}")?;
+                } else {
                     writeln!(
                         output,
                         "        if let Some(value_opt) = &self.{rust_member_name} && let Some(value) = value_opt {{"
                     )?;
-                    writeln!(output, "            {validator}")?;
-                    writeln!(output, "        }}")?;
-                } else {
-                    writeln!(output, "        if let Some(value) = &self.{rust_member_name} {{")?;
                     writeln!(output, "            {validator}")?;
                     writeln!(output, "        }}")?;
                 }
@@ -263,40 +374,6 @@ impl Structure {
         writeln!(output, "        Ok(())")?;
         writeln!(output, "    }}")?;
         writeln!(output, "}}")?;
-        Ok(())
-    }
-}
-
-impl Typed for Structure {
-    fn rust_typename(&self) -> String {
-        self.rust_typename.clone().expect("Structure type should be resolved before generating Rust code")
-    }
-
-    fn get_clap_parser(&self) -> String {
-        let typename = self.rust_typename();
-        format!("{typename}::from_str")
-    }
-
-    fn mark_reachable_from_input(&mut self) {
-        if self.reachable_from_input {
-            return;
-        }
-
-        self.reachable_from_input = true;
-
-        self.members.values_mut().for_each(|member| {
-            member.mark_reachable_from_input();
-        });
-    }
-
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        self.write_rust_decl(output)?;
-        self.write_rust_impl(output)?;
-        if self.reachable_from_input {
-            self.write_rust_from_str_impl(output)?;
-            self.write_rust_try_from_shorthand_value_impl(output)?;
-        }
-        self.write_builder_validate(output)?;
         Ok(())
     }
 }

--- a/scratchstack-shapegen/src/trait_id.rs
+++ b/scratchstack-shapegen/src/trait_id.rs
@@ -1,0 +1,148 @@
+use {
+    serde::{
+        Deserialize, Serialize,
+        de::{Deserializer, Visitor},
+        ser::Serializer,
+    },
+    std::fmt::{Formatter, Result as FmtResult},
+    strum_macros::{Display, EnumString},
+};
+
+/// Trait identifiers.
+#[derive(Clone, Copy, Debug, Display, EnumString, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum TraitId {
+    /// Service trait: `aws.api#service`
+    #[strum(serialize = "aws.api#service")]
+    AwsApiService,
+
+    /// AWS SigV4 authentication trait: `aws.auth#sigv4`
+    #[strum(serialize = "aws.auth#sigv4")]
+    AwsAuthSigV4,
+
+    /// AWSQuery protocol marker trait: `aws.protocols#awsQuery`
+    #[strum(serialize = "aws.protocols#awsQuery")]
+    AwsProtocolsAwsQuery,
+
+    /// AWSQuery error marker trait: `aws.protocols#awsQueryError`
+    #[strum(serialize = "aws.protocols#awsQueryError")]
+    AwsProtocolsAwsQueryError,
+
+    /// Added default trait (service-generated default): `smithy.api#addedDefault`
+    #[strum(serialize = "smithy.api#addedDefault")]
+    SmithyApiAddedDefault,
+
+    /// Default value trait: `smithy.api#default`
+    #[strum(serialize = "smithy.api#default")]
+    SmithyApiDefault,
+
+    /// Documentation trait: `smithy.api#documentation`
+    #[strum(serialize = "smithy.api#documentation")]
+    SmithyApiDocumentation,
+
+    /// Enum value trait: `smithy.api#enumValue`
+    #[strum(serialize = "smithy.api#enumValue")]
+    SmithyApiEnumValue,
+
+    /// Error marker trait: `smithy.api#error`
+    #[strum(serialize = "smithy.api#error")]
+    SmithyApiError,
+
+    /// Examples trait: `smithy.api#examples`
+    #[strum(serialize = "smithy.api#examples")]
+    SmithyApiExamples,
+
+    /// HTTP error code trait: `smithy.api#httpError`
+    #[strum(serialize = "smithy.api#httpError")]
+    SmithyApiHttpError,
+
+    /// Input marker trait: `smithy.api#input`
+    #[strum(serialize = "smithy.api#input")]
+    SmithyApiInput,
+
+    /// Length constraint trait: `smithy.api#length`
+    #[strum(serialize = "smithy.api#length")]
+    SmithyApiLength,
+
+    /// Output marker trait: `smithy.api#output`
+    #[strum(serialize = "smithy.api#output")]
+    SmithyApiOutput,
+
+    /// Pagination information trait: `smithy.api#paginated`
+    #[strum(serialize = "smithy.api#paginated")]
+    SmithyApiPaginated,
+
+    /// Regular expression pattern trait: `smithy.api#pattern`
+    #[strum(serialize = "smithy.api#pattern")]
+    SmithyApiPattern,
+
+    /// Range constraint trait: `smithy.api#range`
+    #[strum(serialize = "smithy.api#range")]
+    SmithyApiRange,
+
+    /// Required trait: `smithy.api#required`
+    #[strum(serialize = "smithy.api#required")]
+    SmithyApiRequired,
+
+    /// Sensitive trait: `smithy.api#sensitive`
+    #[strum(serialize = "smithy.api#sensitive")]
+    SmithyApiSensitive,
+
+    /// Suppressions trait: `smithy.api#suppress`
+    #[strum(serialize = "smithy.api#suppress")]
+    SmithyApiSuppress,
+
+    /// Title trait: `smithy.api#title`
+    #[strum(serialize = "smithy.api#title")]
+    SmithyApiTitle,
+
+    /// XML namespace trait: `smithy.api#xmlNamespace`
+    #[strum(serialize = "smithy.api#xmlNamespace")]
+    SmithyApiXmlNamespace,
+
+    /// Endpoint rule set trait: `smithy.rules#endpointRuleSet`
+    #[strum(serialize = "smithy.rules#endpointRuleSet")]
+    SmithyRulesEndpointRuleSet,
+
+    /// Endpoint tests trait: `smithy.rules#endpointTests`
+    #[strum(serialize = "smithy.rules#endpointTests")]
+    SmithyRulesEndpointTests,
+
+    /// Smoke tests trait: `smithy.test#smokeTests`
+    #[strum(serialize = "smithy.test#smokeTests")]
+    SmithyTestSmokeTests,
+
+    /// Waitable (polling) trait: `smithy.waiters#waitable`
+    #[strum(serialize = "smithy.waiters#waitable")]
+    SmithyWaitersWaitable,
+}
+
+struct TraitIdVisitor;
+impl<'de> Visitor<'de> for TraitIdVisitor {
+    type Value = TraitId;
+
+    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+        formatter.write_str("an integer between -2^31 and 2^31")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, s: &str) -> Result<Self::Value, E> {
+        match s.parse() {
+            Ok(trait_id) => Ok(trait_id),
+            Err(e) => {
+                log::error!("Failed to parse trait ID from string '{s}': {e}");
+                Err(serde::de::Error::custom(e))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TraitId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        d.deserialize_str(TraitIdVisitor)
+    }
+}
+
+impl Serialize for TraitId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}

--- a/scratchstack-shapegen/src/trait_map.rs
+++ b/scratchstack-shapegen/src/trait_map.rs
@@ -1,0 +1,164 @@
+use {
+    crate::{LengthConstraint, RangeConstraint, TraitId},
+    serde::{Deserialize, Serialize},
+    serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue},
+    std::{
+        collections::BTreeMap,
+        io::{Result as IoResult, Write},
+    },
+};
+
+/// A map of trait identifiers to their corresponding values.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[repr(transparent)]
+pub struct TraitMap(BTreeMap<TraitId, JsonValue>);
+
+impl TraitMap {
+    /// Creates a new, empty `TraitMap`.
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Returns the AwsQueryError information if present on these traits.
+    #[inline(always)]
+    pub fn aws_query_error(&self) -> Option<JsonValue> {
+        self.0.get(&TraitId::AwsProtocolsAwsQueryError).cloned()
+    }
+
+    /// Returns the enum value, if any, from these traits.
+    #[inline(always)]
+    pub fn enum_value(&self) -> Option<JsonValue> {
+        self.0.get(&TraitId::SmithyApiEnumValue).cloned()
+    }
+
+    /// Returns the enum value as an integer, if any, from these traits.
+    #[inline(always)]
+    pub fn enum_value_as_i64(&self) -> Option<i64> {
+        self.enum_value().and_then(|v| v.as_i64())
+    }
+
+    /// Returns the documentation as a string, if any, from these traits.
+    #[inline(always)]
+    pub fn documentation(&self) -> Option<&str> {
+        self.0.get(&TraitId::SmithyApiDocumentation).and_then(|v| v.as_str())
+    }
+
+    /// Sets the documentation for these traits.
+    pub fn set_documentation(&mut self, documentation: impl Into<String>) {
+        self.0.insert(TraitId::SmithyApiDocumentation, JsonValue::String(documentation.into()));
+    }
+
+    /// If this trait has an error marker, return it.
+    #[inline(always)]
+    pub fn error(&self) -> Option<String> {
+        self.0.get(&TraitId::SmithyApiError).map(|value| value.as_str().unwrap().to_string())
+    }
+
+    /// Indicates whether the trait map has a required constraint.
+    #[inline(always)]
+    pub fn is_required(&self) -> bool {
+        self.0.contains_key(&TraitId::SmithyApiRequired)
+    }
+
+    /// Sets or clears the required flag from the trait map.
+    #[inline(always)]
+    pub fn set_required(&mut self, required: bool) {
+        if required {
+            self.0.insert(TraitId::SmithyApiRequired, JsonValue::Object(JsonMap::new()));
+        } else {
+            self.0.remove(&TraitId::SmithyApiRequired);
+        }
+    }
+
+    /// Returns the length constraint, if any, from these traits.
+    pub fn length_constraint(&self) -> Option<LengthConstraint> {
+        let length = self.0.get(&TraitId::SmithyApiLength)?.as_object()?;
+        let mut result = LengthConstraint::default();
+
+        if let Some(min) = length.get("min").and_then(|v| v.as_u64()) {
+            result.min = Some(min as usize);
+        }
+        if let Some(max) = length.get("max").and_then(|v| v.as_u64()) {
+            result.max = Some(max as usize);
+        }
+
+        Some(result)
+    }
+
+    /// Sets the length constraint for these traits.
+    pub fn set_length_constraint(&mut self, lc: LengthConstraint) {
+        let mut inner = JsonMap::new();
+        if let Some(min) = lc.min {
+            inner.insert("min".to_string(), JsonValue::Number(JsonNumber::from_u128(min as u128).unwrap()));
+        }
+        if let Some(max) = lc.max {
+            inner.insert("max".to_string(), JsonValue::Number(JsonNumber::from_u128(max as u128).unwrap()));
+        }
+        let value = JsonValue::Object(inner);
+        self.0.insert(TraitId::SmithyApiLength, value);
+    }
+
+    /// Returns the pattern regular expression, if any, for this shape.
+    pub fn pattern(&self) -> Option<&str> {
+        self.0.get(&TraitId::SmithyApiPattern).and_then(|v| v.as_str())
+    }
+
+    /// Sets the pattern regular expression for this shape.
+    pub fn set_pattern(&mut self, pattern: impl Into<String>) {
+        self.0.insert(TraitId::SmithyApiPattern, JsonValue::String(pattern.into()));
+    }
+
+    /// Returns the range constraint, if any, for this shape.
+    pub fn range_constraint(&self) -> Option<RangeConstraint> {
+        let range = self.0.get(&TraitId::SmithyApiRange)?.as_object()?;
+        let mut result = RangeConstraint::default();
+
+        if let Some(min) = range.get("min").and_then(|v| v.as_i64()) {
+            result.min = Some(min);
+        }
+        if let Some(max) = range.get("max").and_then(|v| v.as_i64()) {
+            result.max = Some(max);
+        }
+
+        Some(result)
+    }
+
+    /// Writes documentation comments for this shape to the given output.
+    pub fn write_docs(&self, output: &mut dyn Write, indent: &str) -> IoResult<()> {
+        if let Some(doc_any) = self.0.get(&TraitId::SmithyApiDocumentation)
+            && let Some(doc) = doc_any.as_str()
+        {
+            for line in doc.lines() {
+                writeln!(output, "{}/// {}", indent, line.trim())?;
+            }
+        } else {
+            writeln!(output, "{}#[allow(missing_docs)]", indent)?;
+        }
+
+        Ok(())
+    }
+
+    /// Indicates whether the trait map has an AWS Query Error marker.
+    #[inline(always)]
+    pub fn is_aws_query_error(&self) -> bool {
+        self.0.contains_key(&TraitId::AwsProtocolsAwsQueryError)
+    }
+
+    /// Indicates whether the trait map is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Indicates whether the trait map has an error marker.
+    #[inline(always)]
+    pub fn is_error(&self) -> bool {
+        self.0.contains_key(&TraitId::SmithyApiError)
+    }
+
+    /// Indicates whether the trait map has an input marker.
+    #[inline(always)]
+    pub fn is_input(&self) -> bool {
+        self.0.contains_key(&TraitId::SmithyApiInput)
+    }
+}

--- a/scratchstack-shapegen/src/union.rs
+++ b/scratchstack-shapegen/src/union.rs
@@ -1,9 +1,8 @@
 use {
-    super::{Member, Typed, to_pascal_case},
+    super::{Member, ShapeBase, ShapeInfo, StrExt as _, forward_shape_info},
     serde::{Deserialize, Serialize},
-    serde_json::Value,
     std::{
-        collections::HashMap,
+        collections::BTreeMap,
         io::{Result as IoResult, Write},
     },
 };
@@ -15,17 +14,15 @@ use {
 /// of each variant.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Union {
-    /// The name of this union in the Smithy model.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub smithy_typename: Option<String>,
+    /// Basic shape information for the `union` type.
+    #[serde(flatten)]
+    pub base: ShapeBase,
 
-    /// The Rust name of this union.
-    ///
-    /// This is resolved during a call to `SmithyModel::resolve`.
-    #[serde(skip, default)]
-    pub rust_typename: Option<String>,
+    /// The members of the union. Each member is a variant of the tagged union, where member names
+    /// are the tags of each variant, and the shapes targeted by members are the values of each
+    /// variant.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub members: BTreeMap<String, Member>,
 
     /// Whether this union is reachable from an API input shape. This is used to determine
     /// whether to generate Clap parsers for this union.
@@ -33,53 +30,14 @@ pub struct Union {
     /// This is resolved during a call to `SmithyModel::resolve`.
     #[serde(skip, default)]
     pub reachable_from_input: bool,
-
-    /// The members of the union. Each member is a variant of the tagged union, where member names
-    /// are the tags of each variant, and the shapes targeted by members are the values of each
-    /// variant.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub members: HashMap<String, Member>,
-
-    /// Traits to apply to the type.
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub traits: HashMap<String, Value>,
 }
 
-impl Typed for Union {
-    fn rust_typename(&self) -> String {
-        self.rust_typename.clone().expect("Union type should be resolved before generating Rust code")
-    }
+impl ShapeInfo for Union {
+    forward_shape_info!(Union, base);
 
-    fn write(&self, output: &mut dyn Write) -> IoResult<()> {
-        let rust_typename = self.rust_typename();
-
-        let docs = self.traits.get("smithy.api#documentation").and_then(|v| v.as_str());
-        if let Some(docs) = docs {
-            for line in docs.lines() {
-                writeln!(output, "/// {}", line.trim())?;
-            }
-        } else {
-            writeln!(output, "#[allow(missing_docs)]")?;
-        }
-
-        writeln!(output, "#[derive(Debug, ::serde::Deserialize, ::serde::Serialize)]")?;
-        writeln!(output, "#[non_exhaustive]")?;
-        writeln!(output, "pub enum {rust_typename} {{")?;
-
-        for (member_name, member) in &self.members {
-            let rust_member_name = to_pascal_case(member_name);
-            let member_type = member.rust_typename();
-            writeln!(output, "    #[serde(tag = \"{member_name}\")]")?;
-            writeln!(output, "    {rust_member_name}({member_type}),")?;
-        }
-
-        writeln!(output, "}}")?;
-        Ok(())
-    }
-
-    fn get_clap_parser(&self) -> String {
+    fn clap_parser(&self) -> Option<String> {
         let typename = self.rust_typename();
-        format!("{typename}::parse")
+        Some(format!("{typename}::parse"))
     }
 
     fn mark_reachable_from_input(&mut self) {
@@ -90,5 +48,24 @@ impl Typed for Union {
         for member in self.members.values_mut() {
             member.mark_reachable_from_input();
         }
+    }
+
+    fn generate(&self, output: &mut dyn Write) -> IoResult<()> {
+        let rust_typename = self.rust_typename();
+        self.base.traits.write_docs(output, "")?;
+
+        writeln!(output, "#[derive(Debug, ::serde::Deserialize, ::serde::Serialize)]")?;
+        writeln!(output, "#[non_exhaustive]")?;
+        writeln!(output, "pub enum {rust_typename} {{")?;
+
+        for (member_name, member) in &self.members {
+            let rust_member_name = member_name.to_pascal_case();
+            let member_type = member.rust_typename();
+            writeln!(output, "    #[serde(tag = \"{member_name}\")]")?;
+            writeln!(output, "    {rust_member_name}({member_type}),")?;
+        }
+
+        writeln!(output, "}}")?;
+        Ok(())
     }
 }

--- a/scratchstack-shapes-iam/Cargo.toml
+++ b/scratchstack-shapes-iam/Cargo.toml
@@ -21,13 +21,18 @@ serde_json = { workspace = true }
 
 [dependencies]
 anyhow.workspace = true
+aws-smithy-runtime-api.workspace = true
+aws-smithy-types.workspace = true
+aws-types.workspace = true
 base64.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, optional = true, features = ["derive"] }
 derive_builder.workspace = true
 regex.workspace = true
-scratchstack-arn = { path = "../scratchstack-arn" }
+scratchstack-arn.path = "../scratchstack-arn"
+scratchstack-cli-utils.path = "../scratchstack-cli-utils"
 serde = { workspace = true, features = ["derive"] }
+# smithy-runtime-api.workspace = true
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["clock"] }

--- a/scratchstack-shapes-iam/build.rs
+++ b/scratchstack-shapes-iam/build.rs
@@ -1,8 +1,7 @@
 use {
     anyhow::{Result as AnyResult, bail},
-    scratchstack_shapegen::{Member, Shape, SmithyModel},
-    serde_json::{Value as JsonValue, json},
-    std::{cell::RefCell, collections::HashMap, env::var, fs::File, io::BufReader, path::Path, rc::Rc},
+    scratchstack_shapegen::{LengthConstraint, Member, Shape, SmithyModel, TraitMap},
+    std::{cell::RefCell, env::var, fs::File, io::BufReader, path::Path, rc::Rc},
 };
 
 /// The IAM APIs to exclude from internal request generation.
@@ -48,18 +47,6 @@ const IAM_PROBLEMATIC_REGEX_1: &str = r"^[a-z0-9]([a-z0-9]|-(?!-)){1,61}[a-z0-9]
 /// The replacement regex pattern to use for the problematic regex pattern in the IAM model.
 const IAM_PROBLEMATIC_REGEX_1_REPLACEMENT: &str = r"^[a-z0-9]([-a-z0-9]){1,61}[a-z0-9]$";
 
-/// Smithy trait id for documentation.
-const TRAIT_ID_DOCUMENTATION: &str = "smithy.api#documentation";
-
-/// Smithy trait id for a length constraint.
-const TRAIT_ID_LENGTH: &str = "smithy.api#length";
-
-/// Smithy trait id for a regular expression pattern.
-const TRAIT_ID_PATTERN: &str = "smithy.api#pattern";
-
-/// Smithy trait id for a required member.
-const TRAIT_ID_REQUIRED: &str = "smithy.api#required";
-
 fn main() {
     generate_iam_shapes().expect("Failed to generate IAM shapes");
 }
@@ -70,26 +57,22 @@ fn generate_iam_shapes() -> AnyResult<()> {
     let file = File::open("iam-2010-05-08.json")?;
     let reader = BufReader::new(file);
     let mut model: SmithyModel = serde_json::from_reader(reader)?;
+    model.add_default_shapes();
+
     let mut new_requests = Vec::with_capacity(128);
 
     // Fix unsupported regular expressions on various types.
     for shape in model.shapes.values_mut() {
         let mut shape = shape.borrow_mut();
-        let Some(traits) = shape.traits_mut() else {
+        let traits = shape.traits_mut();
+
+        let Some(pattern) = traits.pattern() else {
             continue;
         };
 
-        let Some(pattern) = traits.get_mut(TRAIT_ID_PATTERN) else {
-            continue;
-        };
-
-        let JsonValue::String(pattern_str) = pattern else {
-            continue;
-        };
-
-        if pattern_str == IAM_PROBLEMATIC_REGEX_1 {
-            *pattern = json!(IAM_PROBLEMATIC_REGEX_1_REPLACEMENT);
-            traits.insert(TRAIT_ID_LENGTH.to_string(), json!({"min": 3, "max": 63}));
+        if pattern == IAM_PROBLEMATIC_REGEX_1 {
+            traits.set_pattern(IAM_PROBLEMATIC_REGEX_1_REPLACEMENT);
+            traits.set_length_constraint(LengthConstraint::new(Some(3), Some(63)));
         }
     }
 
@@ -98,15 +81,14 @@ fn generate_iam_shapes() -> AnyResult<()> {
         let shape = model.shapes.get_mut(*shape_id).unwrap();
         let mut shape = shape.borrow_mut();
         for member in shape.members_mut().unwrap().values_mut() {
-            let Some(doc) = member.traits.get_mut(TRAIT_ID_DOCUMENTATION) else {
+            let Some(doc) = member.traits.documentation() else {
                 continue;
             };
-            let doc_str = doc.as_str().unwrap();
-            let replacement = doc_str
+            let replacement = doc
                 .replace("<service-principal-name>", "<i>service-principal-name</i>")
                 .replace("<role-name>", "<i>role-name</i>")
                 .replace("<task-uuid>", "<i>task-uuid</i>");
-            *doc = json!(replacement);
+            member.traits.set_documentation(replacement);
         }
     }
 
@@ -137,9 +119,9 @@ fn generate_iam_shapes() -> AnyResult<()> {
         let internal_request_shape_name = format!("{}InternalRequest", base_api_name);
 
         // Add the account_id field to the internal request.
-        let mut traits = HashMap::new();
-        traits.insert(TRAIT_ID_REQUIRED.to_string(), json!(true));
-        traits.insert(TRAIT_ID_DOCUMENTATION.to_string(), json!(ACCOUNT_ID_DOCUMENTATION));
+        let mut traits = TraitMap::new();
+        traits.set_required(true);
+        traits.set_documentation(ACCOUNT_ID_DOCUMENTATION);
         let account_id_member = Member {
             shape: None,
             target: ACCOUNT_ID_SHAPE_ID.to_string(),

--- a/scratchstack-shapes-iam/src/iam.rs
+++ b/scratchstack-shapes-iam/src/iam.rs
@@ -2,9 +2,7 @@
 
 use {
     anyhow::{Result as AnyResult, bail},
-    derive_builder::Builder,
-    serde::{Deserialize, Serialize},
-    std::{collections::HashMap, str::FromStr},
+    std::str::FromStr,
 };
 
 // mod account_id;

--- a/scratchstack-shapes-iam/src/lib.rs
+++ b/scratchstack-shapes-iam/src/lib.rs
@@ -24,9 +24,33 @@ pub use scratchstack_arn::{self, Arn};
 #[cfg(feature = "clap")]
 pub mod clap_utils;
 
-/// AWS CLI shorthand notation shapes.
-pub mod shorthand;
-
 /// Identity and Access Management (IAM) API shapes.
 pub(crate) mod iam;
 pub use iam::*;
+
+/// Error types for shapes.
+pub mod error {
+    pub(crate) mod sealed_unhandled {
+        /// This struct is not intended to be used.
+        ///
+        /// This struct holds information about an unhandled error,
+        /// but that information should be obtained by using the
+        /// [`ProvideErrorMetadata`](::aws_smithy_types::error::metadata::ProvideErrorMetadata) trait
+        /// on the error type.
+        ///
+        /// This struct intentionally doesn't yield any useful information itself.
+        #[deprecated(note = "Matching `Unhandled` directly is not forwards compatible. Instead, match using a \
+        variable wildcard pattern and check `.code()`:
+        \
+        &nbsp;&nbsp;&nbsp;`err if err.code() == Some(\"SpecificExceptionCode\") => { /* handle the error */ }`
+        \
+        See [`ProvideErrorMetadata`](::aws_smithy_types::error::metadata::ProvideErrorMetadata) for what information is available for the error.")]
+        #[derive(Debug)]
+        pub struct Unhandled {
+            #[allow(dead_code)]
+            pub(crate) source: ::aws_smithy_runtime_api::box_error::BoxError,
+            #[allow(dead_code)]
+            pub(crate) meta: ::aws_smithy_types::error::metadata::ErrorMetadata,
+        }
+    }
+}


### PR DESCRIPTION
This fixes a lot of random loose ends that were present in the shapegen codebase, mainly functions that should have been in a centralized trait and putting common naming functionality into a ShapeBase struct.

TraitIds also come from an enum now, which makes it easier to query from a TraitMap.