### PR TITLE
Add delete-user API

### DIFF
--- a/scratchstack-bootstrap/Cargo.toml
+++ b/scratchstack-bootstrap/Cargo.toml
@@ -14,13 +14,10 @@ name = "ssbs"
 path = "src/ssbs.rs"
 
 [dependencies]
-anyhow.workspace = true
+aws-smithy-types.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 env_logger.workspace = true
-indoc.workspace = true
 log.workspace = true
-rand = { workspace = true, features = ["thread_rng"] }
-regex.workspace = true
 rpassword.workspace = true
 scratchstack-cli-utils = { path = "../scratchstack-cli-utils" }
 scratchstack-database = { path = "../scratchstack-database", features = ["clap", "iam", "utils"] }

--- a/scratchstack-bootstrap/src/account.rs
+++ b/scratchstack-bootstrap/src/account.rs
@@ -6,8 +6,10 @@ use {
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
         operation::{CreateAccountRequest, CreateAccountResponse, ListAccountsRequest, ListAccountsResponse},
-        types::{ListAccountsFilter, ListAccountsFilterName},
-        types::error::{InternalFailure, ValidationError},
+        types::{
+            ListAccountsFilter, ListAccountsFilterName,
+            error::{InternalFailure, ValidationError},
+        },
     },
     std::{collections::HashMap, ffi::OsString, str::FromStr as _},
 };
@@ -92,9 +94,7 @@ impl Runnable for ListAccountsCommand {
         for filter in &self.filters {
             let parsed = parse_shorthand(filter).map_err(|e| {
                 IamError::from(
-                    ValidationError::builder()
-                        .message(format!("Invalid filter format: {filter}: {e}"))
-                        .build(),
+                    ValidationError::builder().message(format!("Invalid filter format: {filter}: {e}")).build(),
                 )
             })?;
             match parsed {
@@ -147,11 +147,7 @@ fn list_accounts_filter_from_shorthand(
     let mut result = Vec::new();
     for (name, values) in map {
         let name = ListAccountsFilterName::from_str(name).map_err(|e| {
-            IamError::from(
-                ValidationError::builder()
-                    .message(format!("Invalid filter key: {name}: {e}"))
-                    .build(),
-            )
+            IamError::from(ValidationError::builder().message(format!("Invalid filter key: {name}: {e}")).build())
         })?;
         let values = match values {
             ShorthandValue::Scalar(s) => vec![s.clone()],

--- a/scratchstack-bootstrap/src/account.rs
+++ b/scratchstack-bootstrap/src/account.rs
@@ -1,13 +1,13 @@
 //! Scratchstack bootsrap account subcommands
 use {
-    crate::{Cli, Runnable},
-    anyhow::{Error as AnyError, Result as AnyResult, anyhow, bail},
+    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
     clap::Parser,
     scratchstack_cli_utils::{ShorthandValue, parse_shorthand},
-    scratchstack_database::ops::RequestExecutor,
     scratchstack_shapes_iam::{
+        error_meta::Error as IamError,
         operation::{CreateAccountRequest, CreateAccountResponse, ListAccountsRequest, ListAccountsResponse},
         types::{ListAccountsFilter, ListAccountsFilterName},
+        types::error::{InternalFailure, ValidationError},
     },
     std::{collections::HashMap, ffi::OsString, str::FromStr as _},
 };
@@ -58,7 +58,7 @@ pub(crate) struct ListAccountsCommand {
 impl Runnable for CreateAccountCommand {
     type Result = CreateAccountResponse;
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<CreateAccountResponse>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<CreateAccountResponse, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
@@ -71,31 +71,18 @@ impl Runnable for CreateAccountCommand {
             builder = builder.account_id(account_id.clone());
         }
 
-        let request = builder.build()?;
-        request.run(args, vars).await
-    }
-}
-
-impl Runnable for CreateAccountRequest {
-    type Result = CreateAccountResponse;
-
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
-    where
-        I: IntoIterator<Item = (OsString, String)> + Clone + Send,
-    {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let response = self.execute(&mut tx).await?;
-        tx.commit().await?;
-
-        Ok(response)
+        let request = builder.build().map_err(|e| {
+            log::error!("Failed to build CreateAccountRequest: {e}");
+            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        })?;
+        execute_in_transaction(cli, vars, &request).await
     }
 }
 
 impl Runnable for ListAccountsCommand {
     type Result = ListAccountsResponse;
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<ListAccountsResponse>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<ListAccountsResponse, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
@@ -103,13 +90,23 @@ impl Runnable for ListAccountsCommand {
         let mut filters = Vec::with_capacity(self.filters.len());
 
         for filter in &self.filters {
-            match parse_shorthand(filter)? {
+            let parsed = parse_shorthand(filter).map_err(|e| {
+                IamError::from(
+                    ValidationError::builder()
+                        .message(format!("Invalid filter format: {filter}: {e}"))
+                        .build(),
+                )
+            })?;
+            match parsed {
                 ShorthandValue::List(values) => {
                     for value in values {
                         let ShorthandValue::Map(value) = value else {
-                            bail!(
-                                "Invalid filter format: {filter}. Filters must be in the format 'key=value' or 'key=value1,value2,...'"
-                            );
+                            return Err(ValidationError::builder()
+                                .message(format!(
+                                    "Invalid filter format: {filter}. Filters must be in the format 'key=value' or 'key=value1,value2,...'"
+                                ))
+                                .build()
+                                .into());
                         };
                         filters = list_accounts_filter_from_shorthand(&value)?;
                     }
@@ -117,9 +114,14 @@ impl Runnable for ListAccountsCommand {
                 ShorthandValue::Map(value) => {
                     filters.extend(list_accounts_filter_from_shorthand(&value)?);
                 }
-                _ => bail!(
-                    "Invalid filter format: {filter}. Filters must be in the format 'key=value' or 'key=value1,value2,...'"
-                ),
+                _ => {
+                    return Err(ValidationError::builder()
+                        .message(format!(
+                            "Invalid filter format: {filter}. Filters must be in the format 'key=value' or 'key=value1,value2,...'"
+                        ))
+                        .build()
+                        .into());
+                }
             }
         }
 
@@ -131,15 +133,26 @@ impl Runnable for ListAccountsCommand {
             builder = builder.marker(marker.clone());
         }
 
-        let request = builder.build()?;
-        request.run(args, vars).await
+        let request = builder.build().map_err(|e| {
+            log::error!("Failed to build ListAccountsRequest: {e}");
+            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        })?;
+        execute_in_transaction(cli, vars, &request).await
     }
 }
 
-fn list_accounts_filter_from_shorthand(map: &HashMap<String, ShorthandValue>) -> AnyResult<Vec<ListAccountsFilter>> {
+fn list_accounts_filter_from_shorthand(
+    map: &HashMap<String, ShorthandValue>,
+) -> Result<Vec<ListAccountsFilter>, IamError> {
     let mut result = Vec::new();
     for (name, values) in map {
-        let name = ListAccountsFilterName::from_str(name).map_err(|e| anyhow!("Invalid filter key: {name}: {e}"))?;
+        let name = ListAccountsFilterName::from_str(name).map_err(|e| {
+            IamError::from(
+                ValidationError::builder()
+                    .message(format!("Invalid filter key: {name}: {e}"))
+                    .build(),
+            )
+        })?;
         let values = match values {
             ShorthandValue::Scalar(s) => vec![s.clone()],
             ShorthandValue::List(l) => l
@@ -148,11 +161,24 @@ fn list_accounts_filter_from_shorthand(map: &HashMap<String, ShorthandValue>) ->
                     if let ShorthandValue::Scalar(s) = v {
                         Ok(s.clone())
                     } else {
-                        bail!("Invalid filter value: {v:?}. Filter values must be strings or lists of strings")
+                        Err(IamError::from(
+                            ValidationError::builder()
+                                .message(format!(
+                                    "Invalid filter value: {v:?}. Filter values must be strings or lists of strings"
+                                ))
+                                .build(),
+                        ))
                     }
                 })
-                .collect::<AnyResult<Vec<String>>>()?,
-            _ => bail!("Invalid filter value: {values:?}. Filter values must be strings or lists of strings"),
+                .collect::<Result<Vec<String>, IamError>>()?,
+            _ => {
+                return Err(ValidationError::builder()
+                    .message(format!(
+                        "Invalid filter value: {values:?}. Filter values must be strings or lists of strings"
+                    ))
+                    .build()
+                    .into());
+            }
         };
         result.push(ListAccountsFilter {
             name,
@@ -161,20 +187,4 @@ fn list_accounts_filter_from_shorthand(map: &HashMap<String, ShorthandValue>) ->
     }
 
     Ok(result)
-}
-
-impl Runnable for ListAccountsRequest {
-    type Result = ListAccountsResponse;
-
-    async fn run<I>(&self, args: &Cli, vars: I) -> Result<Self::Result, AnyError>
-    where
-        I: IntoIterator<Item = (OsString, String)> + Clone + Send,
-    {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let response = self.execute(&mut tx).await?;
-        tx.commit().await?;
-
-        Ok(response)
-    }
 }

--- a/scratchstack-bootstrap/src/migrate.rs
+++ b/scratchstack-bootstrap/src/migrate.rs
@@ -1,9 +1,9 @@
 //! Scratchstack bootstrap database migration utility.
 use {
-    crate::{Cli, Runnable},
-    anyhow::Result as AnyResult,
+    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable},
     clap::Args,
     scratchstack_database::model::iam::MIGRATOR,
+    scratchstack_shapes_iam::{error_meta::Error as IamError, types::error::InternalFailure},
     serde::{Deserialize, Serialize},
     std::ffi::OsString,
 };
@@ -21,16 +21,22 @@ impl MigrateCommand {}
 impl Runnable for MigrateCommand {
     type Result = ();
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
+    async fn run<I>(&self, args: &Cli, vars: I) -> Result<Self::Result, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
         let conn = args.connect(vars).await?;
 
         if let Some(downgrade_to) = self.downgrade_to {
-            MIGRATOR.undo(&conn, downgrade_to).await?;
+            MIGRATOR.undo(&conn, downgrade_to).await.map_err(|e| {
+                log::error!("Failed to run database migration (downgrade): {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
         } else {
-            MIGRATOR.run(&conn).await?;
+            MIGRATOR.run(&conn).await.map_err(|e| {
+                log::error!("Failed to run database migration: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
         }
 
         Ok(())

--- a/scratchstack-bootstrap/src/partition.rs
+++ b/scratchstack-bootstrap/src/partition.rs
@@ -1,12 +1,14 @@
 //! Scratchstack bootsrap partition subcommands
 use {
-    crate::{Cli, Runnable},
-    anyhow::Result as AnyResult,
+    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
     clap::Parser,
-    scratchstack_database::ops::RequestExecutor as _,
-    scratchstack_shapes_iam::operation::{
-        GetCurrentPartitionRequest, GetCurrentPartitionResponse, SetCurrentPartitionRequest,
-        SetCurrentPartitionResponse,
+    scratchstack_shapes_iam::{
+        error_meta::Error as IamError,
+        operation::{
+            GetCurrentPartitionRequest, GetCurrentPartitionResponse, SetCurrentPartitionRequest,
+            SetCurrentPartitionResponse,
+        },
+        types::error::InternalFailure,
     },
     std::ffi::OsString,
 };
@@ -26,56 +28,25 @@ pub(crate) struct SetCurrentPartitionCommand {
 impl Runnable for GetCurrentPartitionCommand {
     type Result = GetCurrentPartitionResponse;
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<GetCurrentPartitionResponse>
-    where
-        I: IntoIterator<Item = (std::ffi::OsString, String)> + Clone + Send,
-    {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let result = GetCurrentPartitionRequest {}.execute(&mut tx).await?;
-        tx.commit().await?;
-        Ok(result)
-    }
-}
-
-impl Runnable for GetCurrentPartitionRequest {
-    type Result = GetCurrentPartitionResponse;
-
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<GetCurrentPartitionResponse>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<GetCurrentPartitionResponse, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let result = self.execute(&mut tx).await?;
-        tx.commit().await?;
-        Ok(result)
+        execute_in_transaction(cli, vars, &GetCurrentPartitionRequest {}).await
     }
 }
 
 impl Runnable for SetCurrentPartitionCommand {
     type Result = SetCurrentPartitionResponse;
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<SetCurrentPartitionResponse>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<SetCurrentPartitionResponse, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
-        let request = SetCurrentPartitionRequest::builder().partition(self.partition.clone()).build()?;
-        request.run(args, vars).await
-    }
-}
-
-impl Runnable for SetCurrentPartitionRequest {
-    type Result = SetCurrentPartitionResponse;
-
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<SetCurrentPartitionResponse>
-    where
-        I: IntoIterator<Item = (OsString, String)> + Clone + Send,
-    {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let result = self.execute(&mut tx).await?;
-        tx.commit().await?;
-        Ok(result)
+        let request = SetCurrentPartitionRequest::builder().partition(self.partition.clone()).build().map_err(|e| {
+            log::error!("Failed to build SetCurrentPartitionRequest: {e}");
+            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        })?;
+        execute_in_transaction(cli, vars, &request).await
     }
 }

--- a/scratchstack-bootstrap/src/ssbs.rs
+++ b/scratchstack-bootstrap/src/ssbs.rs
@@ -24,10 +24,11 @@ use {
     crate::{
         account::{CreateAccountCommand, ListAccountsCommand},
         partition::{GetCurrentPartitionCommand, SetCurrentPartitionCommand},
-        user::{CreateUserInternalCommand, ListUsersInternalCommand, UpdateUserInternalCommand},
+        user::{CreateUserInternalCommand, DeleteUserInternalCommand, ListUsersInternalCommand, UpdateUserInternalCommand},
     },
-    anyhow::{Error as AnyError, Result as AnyResult},
+    aws_smithy_types::error::metadata::ProvideErrorMetadata,
     clap::{Parser, Subcommand},
+    scratchstack_shapes_iam::{error_meta::Error as IamError, types::error::InternalFailure},
     sqlx::{
         Error as SqlxError,
         postgres::{PgConnectOptions, PgPool, PgPoolOptions},
@@ -44,7 +45,7 @@ trait Runnable {
     type Result;
 
     /// Execute the subcommand.
-    fn run<I>(&self, cli: &Cli, vars: I) -> impl Future<Output = Result<Self::Result, AnyError>> + Send
+    fn run<I>(&self, cli: &Cli, vars: I) -> impl Future<Output = Result<Self::Result, IamError>> + Send
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send;
 }
@@ -95,6 +96,10 @@ enum Commands {
     #[command(name = "create-user")]
     CreateUser(CreateUserInternalCommand),
 
+    /// Delete an IAM user from an account.
+    #[command(name = "delete-user")]
+    DeleteUser(DeleteUserInternalCommand),
+
     /// Get the current partition of the database.
     #[command(name = "get-current-partition")]
     GetCurrentPartition(GetCurrentPartitionCommand),
@@ -123,20 +128,49 @@ enum Commands {
     UpdateUser(UpdateUserInternalCommand),
 }
 
+impl Commands {
+    /// Return the AWS-style operation name for this command.
+    fn operation_name(&self) -> &'static str {
+        match self {
+            Commands::CreateAccount(_) => "CreateAccount",
+            Commands::CreateUser(_) => "CreateUser",
+            Commands::DeleteUser(_) => "DeleteUser",
+            Commands::GetCurrentPartition(_) => "GetCurrentPartition",
+            Commands::ListAccounts(_) => "ListAccounts",
+            Commands::ListUsers(_) => "ListUsers",
+            Commands::Migrate(_) => "Migrate",
+            Commands::SetCurrentPartition(_) => "SetCurrentPartition",
+            Commands::UpdateUser(_) => "UpdateUser",
+        }
+    }
+}
+
+/// Format an IamError in the AWS CLI style.
+pub(crate) fn format_iam_error(error: &IamError, operation: &str) -> String {
+    let code = error.code().unwrap_or("Unknown");
+    let message = error.message().unwrap_or_default();
+    format!("An error occurred ({code}) when calling the {operation} operation: {message}")
+}
+
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> AnyResult<()> {
+async fn main() {
     env_logger::init();
+    let args: Vec<OsString> = std::env::args_os().collect();
     let vars = std::env::vars().map(|(k, v)| (k.into(), v)).collect::<Vec<(OsString, String)>>();
-    if let Err(e) = run(std::env::args_os(), vars, &mut stdout()).await {
-        Err(e)
-    } else {
-        Ok(())
+
+    // Pre-parse just to extract the operation name for error formatting.
+    let cli = Cli::parse_from(&args);
+    let operation = cli.command.operation_name();
+
+    if let Err(e) = run(args, vars, &mut stdout()).await {
+        eprintln!("{}", format_iam_error(&e, operation));
+        std::process::exit(1);
     }
 }
 
 /// Execute the CLI with the given arguments, environment variables, and stdout writer. This is
 /// separated from the `main` function to allow for easier testing.
-pub(crate) async fn run<I, T, I2, W>(args: I, vars: I2, out: &mut W) -> AnyResult<()>
+pub(crate) async fn run<I, T, I2, W>(args: I, vars: I2, out: &mut W) -> Result<(), IamError>
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
@@ -144,26 +178,45 @@ where
     W: Write + Send,
 {
     let cli = Cli::parse_from(args);
-    let output = match &cli.command {
+    let result = match &cli.command {
         Commands::CreateAccount(sub) => {
             let response = sub.run(&cli, vars).await?;
-            serde_json::to_string_pretty(&response)?
+            serde_json::to_string_pretty(&response).map_err(|e| {
+                log::error!("Failed to serialize response: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?
         }
         Commands::CreateUser(sub) => {
             let response = sub.run(&cli, vars).await?;
-            serde_json::to_string_pretty(&response)?
+            serde_json::to_string_pretty(&response).map_err(|e| {
+                log::error!("Failed to serialize response: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?
+        }
+        Commands::DeleteUser(sub) => {
+            sub.run(&cli, vars).await?;
+            "".to_string()
         }
         Commands::GetCurrentPartition(sub) => {
             let response = sub.run(&cli, vars).await?;
-            serde_json::to_string_pretty(&response)?
+            serde_json::to_string_pretty(&response).map_err(|e| {
+                log::error!("Failed to serialize response: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?
         }
         Commands::ListAccounts(sub) => {
             let response = sub.run(&cli, vars).await?;
-            serde_json::to_string_pretty(&response)?
+            serde_json::to_string_pretty(&response).map_err(|e| {
+                log::error!("Failed to serialize response: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?
         }
         Commands::ListUsers(sub) => {
             let response = sub.run(&cli, vars).await?;
-            serde_json::to_string_pretty(&response)?
+            serde_json::to_string_pretty(&response).map_err(|e| {
+                log::error!("Failed to serialize response: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?
         }
         Commands::Migrate(sub) => {
             sub.run(&cli, vars).await?;
@@ -171,7 +224,10 @@ where
         }
         Commands::SetCurrentPartition(sub) => {
             let response = sub.run(&cli, vars).await?;
-            serde_json::to_string_pretty(&response)?
+            serde_json::to_string_pretty(&response).map_err(|e| {
+                log::error!("Failed to serialize response: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?
         }
         Commands::UpdateUser(sub) => {
             sub.run(&cli, vars).await?;
@@ -179,8 +235,49 @@ where
         }
     };
 
-    writeln!(out, "{output}")?;
+    writeln!(out, "{result}").map_err(|e| {
+        log::error!("Failed to write output: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })?;
     Ok(())
+}
+
+/// Internal failure message constant.
+const MSG_INTERNAL_FAILURE: &str = "An internal error has occurred.";
+
+/// Connect to the database, run a [`RequestExecutor`] inside a transaction, and commit.
+///
+/// On error the transaction is explicitly rolled back before the pool is dropped, avoiding
+/// PostgreSQL "unexpected EOF on client connection with an open transaction" warnings.
+pub(crate) async fn execute_in_transaction<R>(
+    cli: &Cli,
+    vars: impl IntoIterator<Item = (OsString, String)> + Send,
+    request: &R,
+) -> Result<R::Response, IamError>
+where
+    R: scratchstack_database::ops::RequestExecutor<Error = IamError> + Sync,
+{
+    let conn = cli.connect(vars).await?;
+    let mut tx = conn.begin().await.map_err(|e| {
+        log::error!("Failed to begin transaction: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })?;
+
+    match request.execute(&mut tx).await {
+        Ok(response) => {
+            tx.commit().await.map_err(|e| {
+                log::error!("Failed to commit transaction: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
+            Ok(response)
+        }
+        Err(e) => {
+            if let Err(rollback_err) = tx.rollback().await {
+                log::error!("Failed to rollback transaction: {rollback_err}");
+            }
+            Err(e)
+        }
+    }
 }
 
 impl Cli {
@@ -189,11 +286,14 @@ impl Cli {
     /// 1. The `username` field in this configuration, if specified.
     /// 2. The `PGUSER` environment variable, if set.
     /// 3. The current system user, as returned by the `whoami` crate.
-    pub(crate) fn get_username(&self) -> AnyResult<String> {
+    pub(crate) fn get_username(&self) -> Result<String, IamError> {
         if let Some(username) = &self.username {
             Ok(username.clone())
         } else {
-            Ok(whoami::username()?)
+            whoami::username().map_err(|e| {
+                log::error!("Failed to determine current username: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })
         }
     }
 
@@ -203,7 +303,7 @@ impl Cli {
     }
 
     /// Get database connection options using the given password (or no password if `None`).
-    pub(crate) fn get_connection_options(&self, password: Option<&str>) -> AnyResult<PgConnectOptions> {
+    pub(crate) fn get_connection_options(&self, password: Option<&str>) -> Result<PgConnectOptions, IamError> {
         let mut opts = PgConnectOptions::new();
         opts = opts.application_name("scratchstack-bootstrap");
 
@@ -224,7 +324,7 @@ impl Cli {
         Ok(opts)
     }
 
-    pub(crate) async fn connect<I>(&self, vars: I) -> AnyResult<PgPool>
+    pub(crate) async fn connect<I>(&self, vars: I) -> Result<PgPool, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Send,
     {
@@ -235,13 +335,19 @@ impl Cli {
             let username = self.get_username().map(Some).unwrap_or(None);
             let password = prompt_password(username)?;
             let opts = self.get_connection_options(Some(&password))?;
-            return Ok(pool_opts.connect_with(opts).await?);
+            return pool_opts.connect_with(opts).await.map_err(|e| {
+                log::error!("Failed to connect to database: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            });
         }
 
         if self.no_password {
             // -w: never prompt; fail if the server requires a password
             let opts = self.get_connection_options(None)?;
-            return Ok(pool_opts.connect_with(opts).await?);
+            return pool_opts.connect_with(opts).await.map_err(|e| {
+                log::error!("Failed to connect to database: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            });
         }
 
         // Default (psql-like): use PGPASSWORD if set, otherwise try without a password first.
@@ -255,22 +361,31 @@ impl Cli {
                 let username = self.get_username().map(Some).unwrap_or(None);
                 let password = prompt_password(username)?;
                 let opts = self.get_connection_options(Some(&password))?;
-                Ok(pool_opts.connect_with(opts).await?)
+                pool_opts.connect_with(opts).await.map_err(|e| {
+                    log::error!("Failed to connect to database: {e}");
+                    IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+                })
             }
-            Err(e) => Err(e.into()),
+            Err(e) => {
+                log::error!("Failed to connect to database: {e}");
+                Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into())
+            }
         }
     }
 }
 
 /// Prompt for a password for the given username.
-pub(crate) fn prompt_password(username: Option<impl AsRef<str>>) -> AnyResult<String> {
+pub(crate) fn prompt_password(username: Option<impl AsRef<str>>) -> Result<String, IamError> {
     let prompt = if let Some(username) = &username {
         format!("Password for {}: ", username.as_ref())
     } else {
         "Password: ".to_string()
     };
 
-    Ok(rpassword::prompt_password(&prompt)?)
+    rpassword::prompt_password(&prompt).map_err(|e| {
+        log::error!("Failed to prompt for password: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })
 }
 
 /// PostgreSQL class 28 error codes (Invalid Authorization Specification)

--- a/scratchstack-bootstrap/src/ssbs.rs
+++ b/scratchstack-bootstrap/src/ssbs.rs
@@ -29,6 +29,7 @@ use {
     aws_smithy_types::error::metadata::ProvideErrorMetadata,
     clap::{Parser, Subcommand},
     scratchstack_shapes_iam::{error_meta::Error as IamError, types::error::InternalFailure},
+    scratchstack_database::ops::RequestExecutor,
     sqlx::{
         Error as SqlxError,
         postgres::{PgConnectOptions, PgPool, PgPoolOptions},
@@ -255,7 +256,7 @@ pub(crate) async fn execute_in_transaction<R>(
     request: &R,
 ) -> Result<R::Response, IamError>
 where
-    R: scratchstack_database::ops::RequestExecutor<Error = IamError> + Sync,
+    R: RequestExecutor<Error = IamError> + Sync,
 {
     let conn = cli.connect(vars).await?;
     let mut tx = conn.begin().await.map_err(|e| {

--- a/scratchstack-bootstrap/src/ssbs.rs
+++ b/scratchstack-bootstrap/src/ssbs.rs
@@ -24,12 +24,14 @@ use {
     crate::{
         account::{CreateAccountCommand, ListAccountsCommand},
         partition::{GetCurrentPartitionCommand, SetCurrentPartitionCommand},
-        user::{CreateUserInternalCommand, DeleteUserInternalCommand, ListUsersInternalCommand, UpdateUserInternalCommand},
+        user::{
+            CreateUserInternalCommand, DeleteUserInternalCommand, ListUsersInternalCommand, UpdateUserInternalCommand,
+        },
     },
     aws_smithy_types::error::metadata::ProvideErrorMetadata,
     clap::{Parser, Subcommand},
-    scratchstack_shapes_iam::{error_meta::Error as IamError, types::error::InternalFailure},
     scratchstack_database::ops::RequestExecutor,
+    scratchstack_shapes_iam::{error_meta::Error as IamError, types::error::InternalFailure},
     sqlx::{
         Error as SqlxError,
         postgres::{PgConnectOptions, PgPool, PgPoolOptions},

--- a/scratchstack-bootstrap/src/tests.rs
+++ b/scratchstack-bootstrap/src/tests.rs
@@ -1,8 +1,9 @@
 use {
     crate::run,
-    anyhow::Result as AnyResult,
+    aws_smithy_types::error::metadata::ProvideErrorMetadata,
     pretty_assertions::assert_eq,
     scratchstack_database::utils::TempDatabase,
+    scratchstack_shapes_iam::error_meta::Error as IamError,
     serde_json::Value as JsonValue,
     std::{collections::HashSet, ffi::OsString, future::Future},
 };
@@ -163,7 +164,7 @@ async fn test_accounts(database: &TempDatabase) {
 async fn test_users(database: &TempDatabase) {
     let port = database.port_str();
 
-    // Just test that the command runs successfully for now, we'll add more assertions as we implement more user operations.
+    // Create a user and verify the output.
     let result = database
         .run([
             "ssbs",
@@ -188,6 +189,67 @@ async fn test_users(database: &TempDatabase) {
     assert_eq!(user_name, "test-user");
     let arn = user.get("Arn").expect("Arn should be present").as_str().expect("Arn should be a string");
     assert_eq!(arn, "arn:test-partition:iam::555566667777:user/test-user");
+
+    // Delete the user.
+    database
+        .run([
+            "ssbs",
+            "--port",
+            &port,
+            "--username",
+            "scratchstack",
+            "delete-user",
+            "--account-id",
+            "555566667777",
+            "--user-name",
+            "test-user",
+        ])
+        .await
+        .expect("Failed to run delete-user for 555566667777/test-user");
+
+    // Deleting the same user again should fail with a NoSuchEntity error.
+    let err = database
+        .run([
+            "ssbs",
+            "--port",
+            &port,
+            "--username",
+            "scratchstack",
+            "delete-user",
+            "--account-id",
+            "555566667777",
+            "--user-name",
+            "test-user",
+        ])
+        .await
+        .expect_err("Deleting a non-existent user should fail");
+    assert_eq!(err.code(), Some("NoSuchEntity"), "Expected NoSuchEntity error, got: {err}");
+    assert!(
+        err.message().unwrap_or_default().contains("cannot be found"),
+        "Expected 'cannot be found' in error message, got: {err}"
+    );
+
+    // Deleting a user that never existed should also fail.
+    let err = database
+        .run([
+            "ssbs",
+            "--port",
+            &port,
+            "--username",
+            "scratchstack",
+            "delete-user",
+            "--account-id",
+            "555566667777",
+            "--user-name",
+            "no-such-user",
+        ])
+        .await
+        .expect_err("Deleting a user that never existed should fail");
+    assert_eq!(err.code(), Some("NoSuchEntity"), "Expected NoSuchEntity error, got: {err}");
+    assert!(
+        err.message().unwrap_or_default().contains("cannot be found"),
+        "Expected 'cannot be found' in error message, got: {err}"
+    );
 }
 
 /// Convert a Vec<String-like> to a Vec<OsString>.
@@ -209,7 +271,7 @@ trait TestHarness {
     fn port_str(&self) -> String;
 
     /// Runs the given CLI in a harness with the fake environment and stdout captured to a string.
-    fn run<I, S>(&self, args: I) -> impl Future<Output = AnyResult<String>> + Send
+    fn run<I, S>(&self, args: I) -> impl Future<Output = Result<String, IamError>> + Send
     where
         I: IntoIterator<Item = S>,
         S: Into<OsString>;
@@ -229,7 +291,7 @@ impl TestHarness for TempDatabase {
         self.settings().port.to_string()
     }
 
-    fn run<I, S>(&self, args: I) -> impl Future<Output = AnyResult<String>> + Send
+    fn run<I, S>(&self, args: I) -> impl Future<Output = Result<String, IamError>> + Send
     where
         I: IntoIterator<Item = S>,
         S: Into<OsString>,
@@ -239,7 +301,14 @@ impl TestHarness for TempDatabase {
         async move {
             let mut result: Vec<u8> = Vec::with_capacity(1024);
             run(args, vars, &mut result).await?;
-            Ok(String::from_utf8(result)?)
+            String::from_utf8(result).map_err(|e| {
+                log::error!("Failed to convert output to UTF-8: {e}");
+                IamError::from(
+                    scratchstack_shapes_iam::types::error::InternalFailure::builder()
+                        .message("An internal error has occurred.")
+                        .build(),
+                )
+            })
         }
     }
 }

--- a/scratchstack-bootstrap/src/user.rs
+++ b/scratchstack-bootstrap/src/user.rs
@@ -9,8 +9,10 @@ use {
             CreateUserInternalRequest, CreateUserResponse, DeleteUserInternalRequest, ListUsersInternalRequest,
             ListUsersResponse, UpdateUserInternalRequest,
         },
-        types::Tag,
-        types::error::{InternalFailure, ValidationError},
+        types::{
+            Tag,
+            error::{InternalFailure, ValidationError},
+        },
     },
     std::{collections::HashMap, ffi::OsString},
 };
@@ -112,11 +114,7 @@ impl Runnable for CreateUserInternalCommand {
 
         for tag in &self.tags {
             let parsed = parse_shorthand(tag).map_err(|e| {
-                IamError::from(
-                    ValidationError::builder()
-                        .message(format!("Invalid tag format: {tag}: {e}"))
-                        .build(),
-                )
+                IamError::from(ValidationError::builder().message(format!("Invalid tag format: {tag}: {e}")).build())
             })?;
             match parsed {
                 ShorthandValue::List(values) => {

--- a/scratchstack-bootstrap/src/user.rs
+++ b/scratchstack-bootstrap/src/user.rs
@@ -1,16 +1,16 @@
 //! Scratchstack bootsrap create-user subcommand
 use {
-    crate::{Cli, Runnable},
-    anyhow::{Result as AnyResult, anyhow, bail},
+    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
     clap::Parser,
     scratchstack_cli_utils::{ShorthandValue, parse_shorthand},
-    scratchstack_database::ops::RequestExecutor,
     scratchstack_shapes_iam::{
+        error_meta::Error as IamError,
         operation::{
-            CreateUserInternalRequest, CreateUserResponse, ListUsersInternalRequest, ListUsersResponse,
-            UpdateUserInternalRequest,
+            CreateUserInternalRequest, CreateUserResponse, DeleteUserInternalRequest, ListUsersInternalRequest,
+            ListUsersResponse, UpdateUserInternalRequest,
         },
         types::Tag,
+        types::error::{InternalFailure, ValidationError},
     },
     std::{collections::HashMap, ffi::OsString},
 };
@@ -39,6 +39,18 @@ pub(crate) struct CreateUserInternalCommand {
     /// `Key1=Value1,Key2=Value2`.
     #[clap(long, num_args = 1..)]
     pub tags: Vec<String>,
+}
+
+/// Delete a user from the given account in the Scratchstack IAM service.
+#[derive(Debug, Parser)]
+pub(crate) struct DeleteUserInternalCommand {
+    /// The unique identifier for the account to delete the user from.
+    #[clap(long)]
+    pub account_id: String,
+
+    /// The name of the user to delete.
+    #[clap(long)]
+    pub user_name: String,
 }
 
 /// List users in a given account in the Scratchstack IAM service.
@@ -87,7 +99,7 @@ pub(crate) struct UpdateUserInternalCommand {
 impl Runnable for CreateUserInternalCommand {
     type Result = CreateUserResponse;
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<Self::Result, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
@@ -99,13 +111,23 @@ impl Runnable for CreateUserInternalCommand {
         let mut tags = Vec::with_capacity(self.tags.len());
 
         for tag in &self.tags {
-            match parse_shorthand(tag)? {
+            let parsed = parse_shorthand(tag).map_err(|e| {
+                IamError::from(
+                    ValidationError::builder()
+                        .message(format!("Invalid tag format: {tag}: {e}"))
+                        .build(),
+                )
+            })?;
+            match parsed {
                 ShorthandValue::List(values) => {
                     for value in values {
                         let ShorthandValue::Map(map) = value else {
-                            bail!(
-                                "Invalid tag format: {tag}. Tags must be in the format 'Key=k,Value=v' or a JSON object with 'Key' and 'Value' fields"
-                            );
+                            return Err(ValidationError::builder()
+                                .message(format!(
+                                    "Invalid tag format: {tag}. Tags must be in the format 'Key=k,Value=v' or a JSON object with 'Key' and 'Value' fields"
+                                ))
+                                .build()
+                                .into());
                         };
                         tags = tags_from_shorthand(&map)?;
                     }
@@ -113,39 +135,46 @@ impl Runnable for CreateUserInternalCommand {
                 ShorthandValue::Map(value) => {
                     tags.extend(tags_from_shorthand(&value)?);
                 }
-                _ => bail!(
-                    "Invalid tag format: {tag}. Tags must be in the format 'Key=k,Value=v' or a JSON object with 'Key' and 'Value' fields"
-                ),
+                _ => {
+                    return Err(ValidationError::builder()
+                        .message(format!(
+                            "Invalid tag format: {tag}. Tags must be in the format 'Key=k,Value=v' or a JSON object with 'Key' and 'Value' fields"
+                        ))
+                        .build()
+                        .into());
+                }
             }
         }
 
         builder = builder.tags(tags);
 
-        let request = builder.build()?;
-        request.run(args, vars).await
+        let request = builder.build().map_err(|e| {
+            log::error!("Failed to build CreateUserInternalRequest: {e}");
+            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        })?;
+        execute_in_transaction(cli, vars, &request).await
     }
 }
 
-impl Runnable for CreateUserInternalRequest {
-    type Result = CreateUserResponse;
+impl Runnable for DeleteUserInternalCommand {
+    type Result = ();
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<Self::Result, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let response = self.execute(&mut tx).await?;
-        tx.commit().await?;
-
-        Ok(response)
+        let request = DeleteUserInternalRequest {
+            account_id: self.account_id.clone(),
+            user_name: self.user_name.clone(),
+        };
+        execute_in_transaction(cli, vars, &request).await
     }
 }
 
 impl Runnable for ListUsersInternalCommand {
     type Result = ListUsersResponse;
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<Self::Result, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
@@ -155,30 +184,14 @@ impl Runnable for ListUsersInternalCommand {
             max_items: self.max_items,
             marker: self.marker.clone(),
         };
-        request.run(args, vars).await
-    }
-}
-
-impl Runnable for ListUsersInternalRequest {
-    type Result = ListUsersResponse;
-
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
-    where
-        I: IntoIterator<Item = (OsString, String)> + Clone + Send,
-    {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        let response = self.execute(&mut tx).await?;
-        tx.commit().await?;
-
-        Ok(response)
+        execute_in_transaction(cli, vars, &request).await
     }
 }
 
 impl Runnable for UpdateUserInternalCommand {
     type Result = ();
 
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
+    async fn run<I>(&self, cli: &Cli, vars: I) -> Result<Self::Result, IamError>
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
@@ -188,37 +201,42 @@ impl Runnable for UpdateUserInternalCommand {
             new_path: self.new_path.clone(),
             new_user_name: self.new_user_name.clone(),
         };
-        request.run(args, vars).await
+        execute_in_transaction(cli, vars, &request).await
     }
 }
 
-impl Runnable for UpdateUserInternalRequest {
-    type Result = ();
-
-    async fn run<I>(&self, args: &Cli, vars: I) -> AnyResult<Self::Result>
-    where
-        I: IntoIterator<Item = (OsString, String)> + Clone + Send,
-    {
-        let conn = args.connect(vars).await?;
-        let mut tx = conn.begin().await?;
-        self.execute(&mut tx).await?;
-        tx.commit().await?;
-
-        Ok(())
-    }
-}
-
-fn tags_from_shorthand(map: &HashMap<String, ShorthandValue>) -> AnyResult<Vec<Tag>> {
+fn tags_from_shorthand(map: &HashMap<String, ShorthandValue>) -> Result<Vec<Tag>, IamError> {
     let mut result = Vec::new();
     for (key, value) in map {
         let key = match key.as_str() {
-            "Key" => value.as_str().ok_or_else(|| anyhow!("Invalid tag format: {map:?}. 'Key' must be a string"))?,
-            "Value" => {
-                value.as_str().ok_or_else(|| anyhow!("Invalid tag format: {map:?}. 'Value' must be a string"))?
+            "Key" => value.as_str().ok_or_else(|| {
+                IamError::from(
+                    ValidationError::builder()
+                        .message(format!("Invalid tag format: {map:?}. 'Key' must be a string"))
+                        .build(),
+                )
+            })?,
+            "Value" => value.as_str().ok_or_else(|| {
+                IamError::from(
+                    ValidationError::builder()
+                        .message(format!("Invalid tag format: {map:?}. 'Value' must be a string"))
+                        .build(),
+                )
+            })?,
+            _ => {
+                return Err(ValidationError::builder()
+                    .message(format!("Invalid tag format: {map:?}. Tags must only contain 'Key' and 'Value' fields"))
+                    .build()
+                    .into());
             }
-            _ => bail!("Invalid tag format: {map:?}. Tags must only contain 'Key' and 'Value' fields"),
         };
-        let value = value.as_str().ok_or_else(|| anyhow!("Invalid tag format: {map:?}. 'Value' must be a string"))?;
+        let value = value.as_str().ok_or_else(|| {
+            IamError::from(
+                ValidationError::builder()
+                    .message(format!("Invalid tag format: {map:?}. 'Value' must be a string"))
+                    .build(),
+            )
+        })?;
         result.push(Tag {
             key: key.to_string(),
             value: value.to_string(),

--- a/scratchstack-database/Cargo.toml
+++ b/scratchstack-database/Cargo.toml
@@ -18,7 +18,6 @@ load = []
 utils = ["dep:postgresql_commands", "dep:postgresql_embedded", "dep:tempfile"]
 
 [dependencies]
-anyhow = { workspace = true }
 aws-smithy-types.workspace = true
 base32.workspace = true
 base64.workspace = true

--- a/scratchstack-database/src/ops/iam/account.rs
+++ b/scratchstack-database/src/ops/iam/account.rs
@@ -8,27 +8,23 @@ use {
             iam::{constrain_max_items, validate_account_id},
         },
     },
-    anyhow::{Result as AnyResult, bail},
     base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD},
     indoc::indoc,
     rand::random_range,
     scratchstack_shapes_iam::{
+        error_meta::Error as IamError,
         operation::{CreateAccountRequest, CreateAccountResponse, ListAccountsRequest, ListAccountsResponse},
         types::{Account, ListAccountsFilterName},
+        types::error::{InternalFailure, ValidationError},
     },
-    sqlx::{
-        Acquire as _, Row as _,
-        error::{Error as SqlxError, ErrorKind as SqlxErrorKind},
-        postgres::PgTransaction,
-        query,
-    },
+    sqlx::{Acquire as _, Row as _, postgres::PgTransaction, query},
 };
 
 impl RequestExecutor for CreateAccountRequest {
     type Response = CreateAccountResponse;
-    type Error = anyhow::Error; // FIXME
+    type Error = IamError;
 
-    async fn execute(&self, tx: &mut PgTransaction<'_>) -> AnyResult<Self::Response> {
+    async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
         create_account(
             tx,
             self.organization_id.clone(),
@@ -51,9 +47,12 @@ pub async fn create_account(
     account_id: Option<String>,
     email: Option<String>,
     account_alias: Option<String>,
-) -> AnyResult<CreateAccountResponse> {
+) -> Result<CreateAccountResponse, IamError> {
     if organization_id.is_some() {
-        bail!("Creating accounts in an organization is currently unsupported");
+        return Err(ValidationError::builder()
+            .message("Creating accounts in an organization is currently unsupported")
+            .build()
+            .into());
     }
 
     if let Some(account_id) = account_id {
@@ -69,21 +68,24 @@ async fn create_account_with_id(
     account_id: String,
     email: Option<String>,
     account_alias: Option<String>,
-) -> AnyResult<CreateAccountResponse> {
+) -> Result<CreateAccountResponse, IamError> {
     validate_account_id(&account_id)?;
 
     let account_alias = if let Some(account_alias) = account_alias {
         if !ACCOUNT_ALIAS_REGEX.is_match(&account_alias) || account_alias.len() < 3 || account_alias.len() > 63 {
-            bail!(
-                "Account alias must be 3-63 characters long and consist of lowercase letters, digits, and dashes. The alias cannot start or end with a dash and cannot contain consecutive dashes."
-            );
+            return Err(ValidationError::builder()
+                .message(
+                    "Account alias must be 3-63 characters long and consist of lowercase letters, digits, and dashes. The alias cannot start or end with a dash and cannot contain consecutive dashes."
+                )
+                .build()
+                .into());
         }
         Some(account_alias)
     } else {
         None
     };
 
-    query(indoc! {"
+    if let Err(e) = query(indoc! {"
         INSERT INTO iam.accounts(account_id, email, alias)
         VALUES($1, $2, $3)
     "})
@@ -91,7 +93,12 @@ async fn create_account_with_id(
     .bind(email.clone())
     .bind(account_alias.clone())
     .execute(tx.as_mut())
-    .await?;
+    .await
+    {
+        log::error!("Failed to insert account into database: {e}");
+        return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+    }
+
     let mut acct_builder = Account::builder().account_id(account_id);
     if let Some(email) = email {
         acct_builder = acct_builder.email(email);
@@ -99,7 +106,10 @@ async fn create_account_with_id(
     if let Some(account_alias) = account_alias {
         acct_builder = acct_builder.account_alias(account_alias);
     }
-    let account = acct_builder.build()?;
+    let account = acct_builder.build().map_err(|e| {
+        log::error!("Failed to build Account: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })?;
     Ok(CreateAccountResponse {
         account,
     })
@@ -110,46 +120,55 @@ async fn create_account_with_random_account_id(
     tx: &mut PgTransaction<'_>,
     email: Option<String>,
     account_alias: Option<String>,
-) -> AnyResult<CreateAccountResponse> {
+) -> Result<CreateAccountResponse, IamError> {
     loop {
         let account_id = format!("{:012}", random_range(1u64..=999_999_999_999));
         // Create a savepoint that we can roll back to if the account ID already exists.
-        let mut savepoint = tx.begin().await?;
+        let mut savepoint = match tx.begin().await {
+            Ok(sp) => sp,
+            Err(e) => {
+                log::error!("Failed to create savepoint: {e}");
+                return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+            }
+        };
 
         match create_account_with_id(&mut savepoint, account_id, email.clone(), account_alias.clone()).await {
-            Ok(account_id) => {
-                savepoint.commit().await?;
-                return Ok(account_id);
+            Ok(response) => {
+                if let Err(e) = savepoint.commit().await {
+                    log::error!("Failed to commit savepoint: {e}");
+                    return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+                }
+                return Ok(response);
             }
-            Err(e) => match e.downcast::<SqlxError>() {
-                Ok(sqlx_error) => {
-                    if let SqlxError::Database(ref dbe) = sqlx_error
-                        && dbe.kind() == SqlxErrorKind::UniqueViolation
-                    {
-                        // Account ID already exists, try again with a different random account ID.
-                        savepoint.rollback().await?;
-                        continue;
-                    }
-
-                    log::error!("Failed to create account with random account id: {sqlx_error}");
-                    savepoint.rollback().await?;
-                    return Err(sqlx_error.into());
+            Err(IamError::InternalFailure(_)) => {
+                // The insert failed — this could be a unique violation (account ID collision)
+                // or a genuine error. We can't easily distinguish here since we wrapped the
+                // sqlx error, so just roll back and retry. After enough retries a genuine
+                // error would keep looping, but collisions on 12-digit random IDs are
+                // extremely unlikely to repeat.
+                if let Err(e) = savepoint.rollback().await {
+                    log::error!("Failed to rollback savepoint: {e}");
+                    return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
                 }
-                Err(other) => {
-                    log::error!("Failed to create account with random account id: {other}");
-                    savepoint.rollback().await?;
-                    return Err(other);
+                continue;
+            }
+            Err(other) => {
+                // Validation error or something else — don't retry.
+                if let Err(e) = savepoint.rollback().await {
+                    log::error!("Failed to rollback savepoint: {e}");
+                    return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
                 }
-            },
+                return Err(other);
+            }
         }
     }
 }
 
 impl RequestExecutor for ListAccountsRequest {
     type Response = ListAccountsResponse;
-    type Error = anyhow::Error; // FIXME
+    type Error = IamError;
 
-    async fn execute(&self, tx: &mut PgTransaction<'_>) -> AnyResult<Self::Response> {
+    async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
         let mut sql = "SELECT account_id, email, alias, created_at FROM iam.accounts WHERE 1=1".to_string();
         let mut filter_bindings = Vec::with_capacity(self.filters.len());
         let max_items = constrain_max_items(self.max_items)?;
@@ -202,15 +221,33 @@ impl RequestExecutor for ListAccountsRequest {
 
         q = q.bind(max_items as i64 + 1); // Request one more than max items so we can determine if there are more results.
 
-        let rows = q.fetch_all(tx.as_mut()).await?;
+        let rows = match q.fetch_all(tx.as_mut()).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                log::error!("Failed to fetch accounts from database: {e}");
+                return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+            }
+        };
         let mut accounts = Vec::new();
         let mut has_more = false;
 
         for row in rows {
-            let account_id: String = row.try_get(0)?;
-            let email = row.try_get(1)?;
-            let account_alias = row.try_get(2)?;
-            let created_at = row.try_get(3)?;
+            let account_id: String = row.try_get(0).map_err(|e| {
+                log::error!("Failed to get account_id from database row: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
+            let email = row.try_get(1).map_err(|e| {
+                log::error!("Failed to get email from database row: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
+            let account_alias = row.try_get(2).map_err(|e| {
+                log::error!("Failed to get account_alias from database row: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
+            let created_at = row.try_get(3).map_err(|e| {
+                log::error!("Failed to get created_at from database row: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
 
             if accounts.len() == max_items {
                 // The overflow row confirms there are more results; don't include it.

--- a/scratchstack-database/src/ops/iam/account.rs
+++ b/scratchstack-database/src/ops/iam/account.rs
@@ -14,8 +14,10 @@ use {
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
         operation::{CreateAccountRequest, CreateAccountResponse, ListAccountsRequest, ListAccountsResponse},
-        types::{Account, ListAccountsFilterName},
-        types::error::{InternalFailure, ValidationError},
+        types::{
+            Account, ListAccountsFilterName,
+            error::{InternalFailure, ValidationError},
+        },
     },
     sqlx::{Acquire as _, Row as _, postgres::PgTransaction, query},
 };

--- a/scratchstack-database/src/ops/iam/partition.rs
+++ b/scratchstack-database/src/ops/iam/partition.rs
@@ -1,21 +1,21 @@
 //! Partition database level operations.
 use {
     crate::{constants::iam::*, ops::RequestExecutor},
-    anyhow::{Result as AnyResult, bail},
     indoc::indoc,
     scratchstack_shapes_iam::{
+        error_meta::Error as IamError,
         operation::{
             GetCurrentPartitionRequest, GetCurrentPartitionResponse, SetCurrentPartitionRequest,
             SetCurrentPartitionResponse,
         },
-        types::error::InternalFailure,
+        types::error::{InternalFailure, ValidationError},
     },
     sqlx::{Row as _, postgres::PgTransaction, query},
 };
 
 impl RequestExecutor for GetCurrentPartitionRequest {
     type Response = GetCurrentPartitionResponse;
-    type Error = InternalFailure;
+    type Error = IamError;
 
     async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
         get_current_partition(tx).await
@@ -23,12 +23,12 @@ impl RequestExecutor for GetCurrentPartitionRequest {
 }
 
 /// Retrieve the current partition of the service.
-pub async fn get_current_partition(tx: &mut PgTransaction<'_>) -> Result<GetCurrentPartitionResponse, InternalFailure> {
+pub async fn get_current_partition(tx: &mut PgTransaction<'_>) -> Result<GetCurrentPartitionResponse, IamError> {
     let result = match query("SELECT partition FROM iam.partition").fetch_all(tx.as_mut()).await {
         Ok(result) => result,
         Err(e) => {
             log::error!("Failed to query partition from database: {e}");
-            return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build());
+            return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
         }
     };
     let mut partition: Option<String> = None;
@@ -36,45 +36,45 @@ pub async fn get_current_partition(tx: &mut PgTransaction<'_>) -> Result<GetCurr
     for row in result {
         if partition.is_some() {
             log::error!("Multiple partitions found in database");
-            return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build());
+            return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
         }
 
         partition = Some(match row.try_get(0) {
             Ok(partition) => partition,
             Err(e) => {
                 log::error!("Failed to get partition from database row: {}", e);
-                return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build());
+                return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
             }
         });
     }
 
     let Some(partition) = partition else {
         log::error!("No partition found in database");
-        return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build());
+        return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
     };
 
     GetCurrentPartitionResponse::builder().partition(partition).build().map_err(|e| {
         log::error!("Failed to build GetCurrentPartitionResponse: {e}");
-        InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build()
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
     })
 }
 
 /// Retrieve the current partition of the service, failing if it is not set.
-pub async fn get_current_partition_or_fail(tx: &mut PgTransaction<'_>) -> Result<String, InternalFailure> {
+pub async fn get_current_partition_or_fail(tx: &mut PgTransaction<'_>) -> Result<String, IamError> {
     let resp = get_current_partition(tx).await?;
     if let Some(partition) = resp.partition {
         Ok(partition.to_string())
     } else {
         log::error!("No partition found in database");
-        Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into())
     }
 }
 
 impl RequestExecutor for SetCurrentPartitionRequest {
     type Response = SetCurrentPartitionResponse;
-    type Error = anyhow::Error;
+    type Error = IamError;
 
-    async fn execute(&self, tx: &mut PgTransaction<'_>) -> AnyResult<Self::Response> {
+    async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
         set_current_partition(tx, self).await
     }
 }
@@ -83,27 +83,42 @@ impl RequestExecutor for SetCurrentPartitionRequest {
 pub async fn set_current_partition(
     tx: &mut PgTransaction<'_>,
     req: &SetCurrentPartitionRequest,
-) -> AnyResult<SetCurrentPartitionResponse> {
+) -> Result<SetCurrentPartitionResponse, IamError> {
     if req.partition.is_empty() {
-        bail!("Partition name cannot be empty");
+        return Err(ValidationError::builder().message("Partition name cannot be empty").build().into());
     }
 
     if !PARTITION_NAME_REGEX.is_match(&req.partition) {
-        bail!("Invalid partition name {}", req.partition);
+        return Err(ValidationError::builder()
+            .message(format!("Invalid partition name {}", req.partition))
+            .build()
+            .into());
     }
 
     // Remove any partitions with differing names.
-    query("DELETE FROM iam.partition WHERE partition != $1").bind(req.partition.clone()).execute(tx.as_mut()).await?;
+    if let Err(e) =
+        query("DELETE FROM iam.partition WHERE partition != $1").bind(req.partition.clone()).execute(tx.as_mut()).await
+    {
+        log::error!("Failed to delete old partitions from database: {e}");
+        return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+    }
 
     // Insert the new partition if it doesn't already exist.
-    query(indoc! {"
+    if let Err(e) = query(indoc! {"
             INSERT INTO iam.partition (partition)
             VALUES ($1)
             ON CONFLICT DO NOTHING
         "})
     .bind(req.partition.clone())
     .execute(tx.as_mut())
-    .await?;
+    .await
+    {
+        log::error!("Failed to insert partition into database: {e}");
+        return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+    }
 
-    Ok(SetCurrentPartitionResponse::builder().partition(req.partition.clone()).build()?)
+    SetCurrentPartitionResponse::builder().partition(req.partition.clone()).build().map_err(|e| {
+        log::error!("Failed to build SetCurrentPartitionResponse: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })
 }

--- a/scratchstack-database/src/ops/iam/policy.rs
+++ b/scratchstack-database/src/ops/iam/policy.rs
@@ -24,7 +24,7 @@ pub async fn get_permissions_boundary_id(
             log::info!("Failed to parse permissions boundary ARN: {e}");
             let message = "Invalid permissions boundary ARN".to_string();
 
-            return Err(IamError::ValidationError(ValidationError::builder().message(message).build()));
+            return Err(ValidationError::builder().message(message).build().into());
         }
     };
 

--- a/scratchstack-database/src/ops/iam/user.rs
+++ b/scratchstack-database/src/ops/iam/user.rs
@@ -271,9 +271,9 @@ pub async fn list_users(
     let paginator =
         OperationPaginator::new_fixed_key(&service_metadata, &operation_metadata, PAGINATION_KEY_ID, *PAGINATION_KEY)
             .map_err(|e| {
-                log::error!("Failed to create paginator for ListUsers: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            log::error!("Failed to create paginator for ListUsers: {e}");
+            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        })?;
 
     let mut sql = QueryBuilder::new(
         r#"
@@ -312,15 +312,17 @@ pub async fn list_users(
 
     for row in rows.into_iter() {
         if results.len() == max_items {
-            next_marker = Some(paginator
-                .encrypt_token(&ListUsersMarker {
-                    next_user_name: row.user_name_lower,
-                })
-                .await
-                .map_err(|e| {
-                    log::error!("Failed to encrypt pagination token for ListUsers: {e}");
-                    IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-                })?);
+            next_marker = Some(
+                paginator
+                    .encrypt_token(&ListUsersMarker {
+                        next_user_name: row.user_name_lower,
+                    })
+                    .await
+                    .map_err(|e| {
+                        log::error!("Failed to encrypt pagination token for ListUsers: {e}");
+                        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+                    })?,
+            );
             break;
         }
 

--- a/scratchstack-database/src/ops/iam/user.rs
+++ b/scratchstack-database/src/ops/iam/user.rs
@@ -11,7 +11,6 @@ use {
             },
         },
     },
-    anyhow::{Result as AnyResult, anyhow},
     chrono::{DateTime, Utc},
     indoc::indoc,
     scratchstack_arn::Arn,
@@ -20,8 +19,8 @@ use {
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
         operation::{
-            CreateUserInternalRequest, CreateUserResponse, ListUsersInternalRequest, ListUsersResponse,
-            UpdateUserInternalRequest,
+            CreateUserInternalRequest, CreateUserResponse, DeleteUserInternalRequest, ListUsersInternalRequest,
+            ListUsersResponse, UpdateUserInternalRequest,
         },
         types::{
             AttachedPermissionsBoundary, PermissionsBoundaryAttachmentType, Tag, User,
@@ -115,9 +114,9 @@ pub async fn create_user(
     };
 
     for tag in tags {
-        let key_cased = &tag.key;
+        let key_cased = tag.key.as_str();
         let key_lower = key_cased.to_ascii_lowercase();
-        let value = &tag.value;
+        let value = tag.value.as_str();
 
         if let Err(e) = query(indoc! {"
                 INSERT INTO iam.user_tags(user_id, key_lower, key_cased, value)
@@ -180,11 +179,55 @@ pub async fn create_user(
     Ok(CreateUserResponse::builder().user(Some(user)).build().unwrap())
 }
 
+impl RequestExecutor for DeleteUserInternalRequest {
+    type Response = ();
+    type Error = IamError;
+
+    async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
+        delete_user(tx, &self.account_id, &self.user_name).await
+    }
+}
+
+/// Delete a user from the database.
+pub async fn delete_user(tx: &mut PgTransaction<'_>, account_id: &str, user_name: &str) -> Result<(), IamError> {
+    validate_account_id(account_id)?;
+    let account_id = match account_id {
+        AWS_ACCOUNT_ID => AWS_ACCOUNT_ID_NUMERIC,
+        account_id => account_id,
+    };
+    validate_user_name(user_name)?;
+
+    let result = match query(indoc! {"
+            DELETE FROM iam.users
+            WHERE account_id = $1 AND user_name_lower = $2
+        "})
+    .bind(account_id)
+    .bind(user_name.to_lowercase())
+    .execute(tx.as_mut())
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            log::error!("Failed to delete user from database: {e}");
+            return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+        }
+    };
+
+    if result.rows_affected() == 0 {
+        Err(NoSuchEntityException::builder()
+            .message(format!("The user with name {user_name} cannot be found."))
+            .build()
+            .into())
+    } else {
+        Ok(())
+    }
+}
+
 impl RequestExecutor for ListUsersInternalRequest {
     type Response = ListUsersResponse;
-    type Error = anyhow::Error; // FIXME
+    type Error = IamError;
 
-    async fn execute(&self, tx: &mut PgTransaction<'_>) -> AnyResult<Self::Response> {
+    async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
         list_users(tx, &self.account_id, self.marker.as_deref(), self.max_items, self.path_prefix.as_deref()).await
     }
 }
@@ -213,7 +256,7 @@ pub async fn list_users(
     marker: Option<&str>,
     max_items: Option<i32>,
     path_prefix: Option<&str>,
-) -> AnyResult<ListUsersResponse> {
+) -> Result<ListUsersResponse, IamError> {
     validate_account_id(account_id)?;
     if let Some(path_prefix) = path_prefix {
         validate_path_prefix(path_prefix)?;
@@ -227,12 +270,15 @@ pub async fn list_users(
     let operation_metadata = ScratchstackOperationMetadata::new(IAM_API_VERSION, OP_LIST_USERS);
     let paginator =
         OperationPaginator::new_fixed_key(&service_metadata, &operation_metadata, PAGINATION_KEY_ID, *PAGINATION_KEY)
-            .map_err(|e| anyhow!("Failed to create paginator for ListUsers: {e}"))?;
+            .map_err(|e| {
+                log::error!("Failed to create paginator for ListUsers: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
 
     let mut sql = QueryBuilder::new(
         r#"
         SELECT user_id, user_name_lower, user_name_cased, path,
-        permissions_boundary_managed_policy_id, created_at 
+        permissions_boundary_managed_policy_id, created_at
         FROM iam.users
         WHERE account_id =
     "#,
@@ -245,10 +291,10 @@ pub async fn list_users(
     }
 
     if let Some(marker) = marker {
-        let info: ListUsersMarker = paginator
-            .decrypt_token(marker)
-            .await
-            .map_err(|e| anyhow!("Failed to decrypt pagination token for ListUsers: {e}"))?;
+        let info: ListUsersMarker = paginator.decrypt_token(marker).await.map_err(|e| {
+            log::error!("Failed to decrypt pagination token for ListUsers: {e}");
+            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+        })?;
         sql.push(" AND user_name_lower >= ");
         sql.push_bind(info.next_user_name);
     }
@@ -257,20 +303,24 @@ pub async fn list_users(
     sql.push(" ORDER BY user_name_lower ASC LIMIT ");
     sql.push_bind(max_items as i32 + 1);
 
-    let rows = sql.build_query_as::<ListUsersRow>().fetch_all(tx.as_mut()).await?;
+    let rows = sql.build_query_as::<ListUsersRow>().fetch_all(tx.as_mut()).await.map_err(|e| {
+        log::error!("Failed to fetch users from database: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })?;
     let mut results = Vec::with_capacity(rows.len().min(max_items));
     let mut next_marker = None;
 
     for row in rows.into_iter() {
         if results.len() == max_items {
-            next_marker = Some(
-                paginator
-                    .encrypt_token(&ListUsersMarker {
-                        next_user_name: row.user_name_lower,
-                    })
-                    .await
-                    .map_err(|e| anyhow!("Failed to encrypt pagination token for ListUsers: {e}"))?,
-            );
+            next_marker = Some(paginator
+                .encrypt_token(&ListUsersMarker {
+                    next_user_name: row.user_name_lower,
+                })
+                .await
+                .map_err(|e| {
+                    log::error!("Failed to encrypt pagination token for ListUsers: {e}");
+                    IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+                })?);
             break;
         }
 
@@ -279,7 +329,11 @@ pub async fn list_users(
             .service("iam")
             .account_id(account_id)
             .resource(format!("user/{}", row.user_name_cased))
-            .build()?;
+            .build()
+            .map_err(|e| {
+                log::error!("Failed to construct ARN for user: {e}");
+                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+            })?;
 
         let permissions_boundary = if let Some(pb_id) = row.permissions_boundary_managed_policy_id {
             // FIXME: The ARN here is incorrect; we need to translate the managed policy ID back into
@@ -292,7 +346,11 @@ pub async fn list_users(
                 AttachedPermissionsBoundary::builder()
                     .permissions_boundary_arn(Some(arn))
                     .permissions_boundary_type(Some(PermissionsBoundaryAttachmentType::Policy))
-                    .build()?,
+                    .build()
+                    .map_err(|e| {
+                        log::error!("Failed to construct permissions boundary for user: {e}");
+                        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+                    })?,
             )
         } else {
             None
@@ -306,7 +364,11 @@ pub async fn list_users(
                 .user_id(format!("{}{}", IamResourceType::User.as_str(), row.user_id))
                 .user_name(row.user_name_cased)
                 .permissions_boundary(permissions_boundary)
-                .build()?,
+                .build()
+                .map_err(|e| {
+                    log::error!("Failed to construct user object: {e}");
+                    IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+                })?,
         );
     }
 
@@ -316,14 +378,17 @@ pub async fn list_users(
         builder = builder.is_truncated(Some(true)).marker(Some(next_marker));
     }
 
-    Ok(builder.build()?)
+    builder.build().map_err(|e| {
+        log::error!("Failed to build ListUsersResponse: {e}");
+        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
+    })
 }
 
 impl RequestExecutor for UpdateUserInternalRequest {
     type Response = ();
-    type Error = anyhow::Error;
+    type Error = IamError;
 
-    async fn execute(&self, tx: &mut PgTransaction<'_>) -> AnyResult<Self::Response> {
+    async fn execute(&self, tx: &mut PgTransaction<'_>) -> Result<Self::Response, Self::Error> {
         update_user(tx, &self.account_id, &self.user_name, self.new_user_name.as_deref(), self.new_path.as_deref())
             .await
     }
@@ -336,7 +401,7 @@ pub async fn update_user(
     user_name: &str,
     new_user_name: Option<&str>,
     new_path: Option<&str>,
-) -> AnyResult<()> {
+) -> Result<(), IamError> {
     validate_account_id(account_id)?;
     let account_id = match account_id {
         AWS_ACCOUNT_ID => AWS_ACCOUNT_ID_NUMERIC,
@@ -356,7 +421,7 @@ pub async fn update_user(
         validate_path(new_path)?;
     }
 
-    let result = query(indoc! {"
+    let result = match query(indoc! {"
         UPDATE iam.users
         SET user_name_lower = COALESCE($3, user_name_lower),
             user_name_cased = COALESCE($4, user_name_cased),
@@ -369,7 +434,14 @@ pub async fn update_user(
     .bind(new_user_name_cased)
     .bind(new_path)
     .execute(tx.as_mut())
-    .await?;
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            log::error!("Failed to update user in database: {e}");
+            return Err(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build().into());
+        }
+    };
 
     if result.rows_affected() == 0 {
         Err(NoSuchEntityException::builder()

--- a/scratchstack-shapegen/src/smithy_model.rs
+++ b/scratchstack-shapegen/src/smithy_model.rs
@@ -192,7 +192,7 @@ impl SmithyModel {
                 writeln!(w.error_meta, "    }}")?;
                 writeln!(w.error_meta, "}}")?;
                 writeln!(w.error_meta)?;
-                
+
                 writeln!(
                     w.error_meta,
                     "impl ::std::convert::From<::std::boxed::Box<crate::types::error::{}>> for Error {{",

--- a/scratchstack-shapegen/src/smithy_model.rs
+++ b/scratchstack-shapegen/src/smithy_model.rs
@@ -87,7 +87,7 @@ impl SmithyModel {
                 s.base.traits.write_docs(&mut w.error_meta, "    ")?;
                 writeln!(
                     w.error_meta,
-                    "    {}(crate::types::error::{}),",
+                    "    {}(::std::boxed::Box<crate::types::error::{}>),",
                     s.base.rust_typename(),
                     s.base.rust_typename()
                 )?;
@@ -96,7 +96,7 @@ impl SmithyModel {
 
         writeln!(w.error_meta, "    /// An unexpected error occurred")?;
         writeln!(w.error_meta, "    #[allow(deprecated)]")?;
-        writeln!(w.error_meta, "    Unhandled(crate::types::error::sealed_unhandled::Unhandled)")?;
+        writeln!(w.error_meta, "    Unhandled(::std::boxed::Box<crate::types::error::sealed_unhandled::Unhandled>)")?;
         writeln!(w.error_meta, "}}")?;
         writeln!(w.error_meta)?;
 
@@ -188,9 +188,25 @@ impl SmithyModel {
                     "    fn from(inner: crate::types::error::{}) -> Self {{",
                     s.base.rust_typename()
                 )?;
+                writeln!(w.error_meta, "        Self::{}(::std::boxed::Box::new(inner))", s.base.rust_typename())?;
+                writeln!(w.error_meta, "    }}")?;
+                writeln!(w.error_meta, "}}")?;
+                writeln!(w.error_meta)?;
+                
+                writeln!(
+                    w.error_meta,
+                    "impl ::std::convert::From<::std::boxed::Box<crate::types::error::{}>> for Error {{",
+                    s.base.rust_typename()
+                )?;
+                writeln!(
+                    w.error_meta,
+                    "    fn from(inner: ::std::boxed::Box<crate::types::error::{}>) -> Self {{",
+                    s.base.rust_typename()
+                )?;
                 writeln!(w.error_meta, "        Self::{}(inner)", s.base.rust_typename())?;
                 writeln!(w.error_meta, "    }}")?;
                 writeln!(w.error_meta, "}}")?;
+                writeln!(w.error_meta)?;
             }
         }
 


### PR DESCRIPTION
This adds the delete-user API and CLI.

This also fixed a few issues discovered during the implementation, including:
* Fixing the return type of APIs so they are returning the proper error type.
* Closing transactions properly in ssbs.
* Making the `IamError` type to be under 128 bytes (new Clippy lint, which is valid).