### PR TITLE
Make Builder structs return ValidationError

### DIFF
--- a/scratchstack-bootstrap/src/account.rs
+++ b/scratchstack-bootstrap/src/account.rs
@@ -1,15 +1,12 @@
 //! Scratchstack bootsrap account subcommands
 use {
-    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
+    crate::{Cli, Runnable, execute_in_transaction},
     clap::Parser,
     scratchstack_cli_utils::{ShorthandValue, parse_shorthand},
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
         operation::{CreateAccountRequest, CreateAccountResponse, ListAccountsRequest, ListAccountsResponse},
-        types::{
-            ListAccountsFilter, ListAccountsFilterName,
-            error::{InternalFailure, ValidationError},
-        },
+        types::{ListAccountsFilter, ListAccountsFilterName, error::ValidationError},
     },
     std::{collections::HashMap, ffi::OsString, str::FromStr as _},
 };
@@ -73,10 +70,7 @@ impl Runnable for CreateAccountCommand {
             builder = builder.account_id(account_id.clone());
         }
 
-        let request = builder.build().map_err(|e| {
-            log::error!("Failed to build CreateAccountRequest: {e}");
-            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-        })?;
+        let request = builder.build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -133,10 +127,7 @@ impl Runnable for ListAccountsCommand {
             builder = builder.marker(marker.clone());
         }
 
-        let request = builder.build().map_err(|e| {
-            log::error!("Failed to build ListAccountsRequest: {e}");
-            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-        })?;
+        let request = builder.build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }

--- a/scratchstack-bootstrap/src/group.rs
+++ b/scratchstack-bootstrap/src/group.rs
@@ -1,6 +1,6 @@
 //! Scratchstack bootstrap group subcommands
 use {
-    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
+    crate::{Cli, Runnable, execute_in_transaction},
     clap::Parser,
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
@@ -10,7 +10,6 @@ use {
             ListGroupsInternalRequest, ListGroupsResponse, RemoveUserFromGroupInternalRequest,
             UpdateGroupInternalRequest,
         },
-        types::error::InternalFailure,
     },
     std::ffi::OsString,
 };
@@ -109,11 +108,7 @@ impl Runnable for CreateGroupInternalCommand {
             .account_id(self.account_id.clone())
             .group_name(self.group_name.clone())
             .path(Some(self.path.clone()))
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build CreateGroupInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -128,11 +123,7 @@ impl Runnable for DeleteGroupInternalCommand {
         let request = DeleteGroupInternalRequest::builder()
             .account_id(self.account_id.clone())
             .group_name(self.group_name.clone())
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build DeleteGroupInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -147,11 +138,7 @@ impl Runnable for GetGroupInternalCommand {
         let request = GetGroupInternalRequest::builder()
             .account_id(self.account_id.clone())
             .group_name(self.group_name.clone())
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build GetGroupInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -253,11 +240,7 @@ impl Runnable for AddUserToGroupInternalCommand {
             .account_id(self.account_id.clone())
             .group_name(self.group_name.clone())
             .user_name(self.user_name.clone())
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build AddUserToGroupInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -290,11 +273,7 @@ impl Runnable for RemoveUserFromGroupInternalCommand {
             .account_id(self.account_id.clone())
             .group_name(self.group_name.clone())
             .user_name(self.user_name.clone())
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build RemoveUserFromGroupInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }

--- a/scratchstack-bootstrap/src/partition.rs
+++ b/scratchstack-bootstrap/src/partition.rs
@@ -1,6 +1,6 @@
 //! Scratchstack bootsrap partition subcommands
 use {
-    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
+    crate::{Cli, Runnable, execute_in_transaction},
     clap::Parser,
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
@@ -8,7 +8,6 @@ use {
             GetCurrentPartitionRequest, GetCurrentPartitionResponse, SetCurrentPartitionRequest,
             SetCurrentPartitionResponse,
         },
-        types::error::InternalFailure,
     },
     std::ffi::OsString,
 };
@@ -43,10 +42,7 @@ impl Runnable for SetCurrentPartitionCommand {
     where
         I: IntoIterator<Item = (OsString, String)> + Clone + Send,
     {
-        let request = SetCurrentPartitionRequest::builder().partition(self.partition.clone()).build().map_err(|e| {
-            log::error!("Failed to build SetCurrentPartitionRequest: {e}");
-            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-        })?;
+        let request = SetCurrentPartitionRequest::builder().partition(self.partition.clone()).build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }

--- a/scratchstack-bootstrap/src/policy.rs
+++ b/scratchstack-bootstrap/src/policy.rs
@@ -1,32 +1,15 @@
 //! Scratchstack bootstrap policy subcommands
 use {
-    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction, user::tags_from_shorthand},
+    crate::{Cli, Runnable, execute_in_transaction, user::tags_from_shorthand},
     clap::Parser,
     scratchstack_shapes_iam::{
         error_meta::Error as IamError,
         operation::{
             CreatePolicyInternalRequest, CreatePolicyResponse, CreatePolicyVersionRequest, CreatePolicyVersionResponse,
         },
-        types::error::{InternalFailure, MalformedPolicyDocumentException},
     },
     std::ffi::OsString,
 };
-
-/// Map a request-builder error string to the most appropriate IAM error.
-///
-/// Builder errors are plain strings produced by smithy codegen and contain a field-type marker
-/// such as `policyDocumentType`. When the failure pertains to the policy document, surface it as
-/// a `MalformedPolicyDocument` error rather than an opaque `InternalFailure`, so callers see the
-/// user-facing class of error AWS IAM uses for the same situation.
-fn map_builder_error(operation: &str, error: impl std::fmt::Display) -> IamError {
-    let message = error.to_string();
-    log::error!("Failed to build {operation}: {message}");
-    if message.contains("policyDocumentType") {
-        IamError::from(MalformedPolicyDocumentException::builder().message(message).build())
-    } else {
-        IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-    }
-}
 
 /// Create a new managed policy in a given account in the Scratchstack IAM service.
 #[derive(Debug, Parser)]
@@ -89,8 +72,7 @@ impl Runnable for CreatePolicyInternalCommand {
             .description(self.description.clone())
             .path(Some(self.path.clone()))
             .tags(tags)
-            .build()
-            .map_err(|e| map_builder_error("CreatePolicyInternalRequest", e))?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -108,7 +90,7 @@ impl Runnable for CreatePolicyVersionCommand {
         if self.set_as_default {
             request_builder = request_builder.set_as_default(Some(true));
         }
-        let request = request_builder.build().map_err(|e| map_builder_error("CreatePolicyVersionRequest", e))?;
+        let request = request_builder.build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }

--- a/scratchstack-bootstrap/src/tests.rs
+++ b/scratchstack-bootstrap/src/tests.rs
@@ -507,7 +507,9 @@ async fn test_users(database: &TempDatabase) {
 async fn test_policies(database: &TempDatabase) {
     let port = database.port_str();
 
-    // Creating a policy with an empty document should fail with MalformedPolicyDocument, not InternalFailure.
+    // Creating a policy with an empty document fails the smithy shape regex/length constraint,
+    // which surfaces as ValidationError. (MalformedPolicyDocument is reserved for documents that
+    // pass shape validation but fail Aspen parsing — covered by the database-layer tests.)
     let err = database
         .run([
             "ssbs",
@@ -525,11 +527,7 @@ async fn test_policies(database: &TempDatabase) {
         ])
         .await
         .expect_err("Creating a policy with an empty document should fail");
-    assert_eq!(
-        err.code(),
-        Some("MalformedPolicyDocument"),
-        "Expected MalformedPolicyDocument error for empty document, got: {err}"
-    );
+    assert_eq!(err.code(), Some("ValidationError"), "Expected ValidationError for empty document, got: {err}");
 }
 
 async fn test_groups(database: &TempDatabase) {

--- a/scratchstack-bootstrap/src/tests.rs
+++ b/scratchstack-bootstrap/src/tests.rs
@@ -507,7 +507,7 @@ async fn test_users(database: &TempDatabase) {
 async fn test_policies(database: &TempDatabase) {
     let port = database.port_str();
 
-    // Creating a policy with an empty document fails the smithy shape regex/length constraint,
+    // Creating a policy with an empty document fails the Smithy shape regex/length constraint,
     // which surfaces as ValidationError. (MalformedPolicyDocument is reserved for documents that
     // pass shape validation but fail Aspen parsing — covered by the database-layer tests.)
     let err = database

--- a/scratchstack-bootstrap/src/user.rs
+++ b/scratchstack-bootstrap/src/user.rs
@@ -1,6 +1,6 @@
 //! Scratchstack bootsrap create-user subcommand
 use {
-    crate::{Cli, MSG_INTERNAL_FAILURE, Runnable, execute_in_transaction},
+    crate::{Cli, Runnable, execute_in_transaction},
     clap::Parser,
     scratchstack_cli_utils::{ShorthandValue, parse_shorthand},
     scratchstack_shapes_iam::{
@@ -10,10 +10,7 @@ use {
             GetUserResponse, ListUserTagsInternalRequest, ListUserTagsResponse, ListUsersInternalRequest,
             ListUsersResponse, TagUserInternalRequest, UntagUserInternalRequest, UpdateUserInternalRequest,
         },
-        types::{
-            Tag,
-            error::{InternalFailure, ValidationError},
-        },
+        types::{Tag, error::ValidationError},
     },
     std::{collections::HashMap, ffi::OsString},
 };
@@ -186,10 +183,7 @@ impl Runnable for CreateUserInternalCommand {
         let tags = tags_from_shorthand(&self.tags)?;
         builder = builder.tags(tags);
 
-        let request = builder.build().map_err(|e| {
-            log::error!("Failed to build CreateUserInternalRequest: {e}");
-            IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-        })?;
+        let request = builder.build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -219,11 +213,7 @@ impl Runnable for GetUserInternalCommand {
         let request = GetUserInternalRequest::builder()
             .user_name(Some(self.user_name.clone()))
             .account_id(self.account_id.clone())
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build GetUserInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -274,11 +264,7 @@ impl Runnable for TagUserInternalCommand {
             .account_id(self.account_id.clone())
             .user_name(self.user_name.clone())
             .tags(tags)
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build TagUserInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }
@@ -294,11 +280,7 @@ impl Runnable for UntagUserInternalCommand {
             .account_id(self.account_id.clone())
             .user_name(self.user_name.clone())
             .tag_keys(self.tag_keys.clone())
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to build UntagUserInternalRequest: {e}");
-                IamError::from(InternalFailure::builder().message(MSG_INTERNAL_FAILURE).build())
-            })?;
+            .build()?;
         execute_in_transaction(cli, vars, &request).await
     }
 }

--- a/scratchstack-shapegen/src/structure.rs
+++ b/scratchstack-shapegen/src/structure.rs
@@ -66,7 +66,7 @@ impl ShapeInfo for Structure {
         } else if is_input || is_output {
             self.write_rust_decl(&mut w.operation)?;
             self.write_rust_impl(&mut w.operation)?;
-            self.write_builder_validate(&mut w.operation)?;
+            self.write_builder(&mut w.operation)?;
 
             if is_input {
                 self.write_shorthand_parser(&mut w.operation)?;
@@ -74,7 +74,7 @@ impl ShapeInfo for Structure {
         } else {
             self.write_rust_decl(&mut w.types)?;
             self.write_rust_impl(&mut w.types)?;
-            self.write_builder_validate(&mut w.types)?;
+            self.write_builder(&mut w.types)?;
             self.write_shorthand_parser(&mut w.types)?;
         }
 
@@ -126,10 +126,6 @@ impl Structure {
         self.base.traits.write_docs(w, "")?;
 
         // Attributes for the structure.
-        if !is_error {
-            writeln!(w, "#[derive(::derive_builder::Builder)]")?;
-            writeln!(w, "#[builder(pattern = \"owned\", build_fn(validate = \"Self::validate\"), setter(into))]")?;
-        }
         writeln!(w, "#[derive(::std::clone::Clone, ::std::cmp::Eq, ::std::cmp::PartialEq, ::std::fmt::Debug)]")?;
         writeln!(w, "#[derive(::serde::Deserialize, ::serde::Serialize)]")?;
         writeln!(w, "pub struct {rust_typename} {{")?;
@@ -156,9 +152,6 @@ impl Structure {
                 writeln!(w, "    #[serde(rename = \"{member_name}\", skip_serializing_if = \"Option::is_none\")]")?;
             } else {
                 writeln!(w, "    #[serde(rename = \"{member_name}\")]")?;
-            }
-            if !is_error && (is_optional || is_list) {
-                writeln!(w, "    #[builder(default)]")?;
             }
             writeln!(w, "    pub {rust_member_name}: {member_type},")?;
         }
@@ -265,13 +258,47 @@ impl Structure {
         Ok(())
     }
 
-    /// Writes the derive_builder validation function for this structure, which checks that all
-    /// required fields are set and that all fields satisfy any constraints specified in the model.
-    fn write_builder_validate(&self, w: &mut dyn Write) -> IoResult<()> {
+    /// Writes a hand-rolled builder for this non-error structure.
+    ///
+    /// The builder mirrors the call-site contract of the previous `derive_builder`-based
+    /// implementation: setters take `impl Into<T>` where `T` is the struct field type, all
+    /// internal storage is `Option<T>`, and `build()` runs validation and returns a typed
+    /// `ValidationError` on failure instead of an opaque builder error.
+    fn write_builder(&self, w: &mut dyn Write) -> IoResult<()> {
         let rust_typename = self.base.rust_typename();
+
+        // 1. The builder struct itself.
+        writeln!(w, "/// Builder for [`{rust_typename}`].")?;
+        writeln!(w, "#[derive(::std::clone::Clone, ::std::fmt::Debug, ::std::default::Default)]")?;
+        writeln!(w, "pub struct {rust_typename}Builder {{")?;
+        for (member_name, member) in &self.members {
+            let rust_member_name = member_name.to_snake_case();
+            let field_type = self.builder_field_type(member);
+            writeln!(w, "    {rust_member_name}: ::std::option::Option<{field_type}>,")?;
+        }
+        writeln!(w, "}}")?;
+        writeln!(w)?;
+
         writeln!(w, "impl {rust_typename}Builder {{")?;
+
+        // 2. Per-field setters, matching derive_builder's `setter(into)` semantics.
+        for (member_name, member) in &self.members {
+            let rust_member_name = member_name.to_snake_case();
+            let field_type = self.builder_field_type(member);
+            writeln!(w, "    /// Sets the `{member_name}` field.")?;
+            writeln!(
+                w,
+                "    pub fn {rust_member_name}(mut self, value: impl ::std::convert::Into<{field_type}>) -> Self {{"
+            )?;
+            writeln!(w, "        self.{rust_member_name} = ::std::option::Option::Some(value.into());")?;
+            writeln!(w, "        self")?;
+            writeln!(w, "    }}")?;
+            writeln!(w)?;
+        }
+
+        // 3. The private validate() method (kept verbatim from the prior implementation).
         writeln!(w, "    #[allow(clippy::collapsible_if)]")?;
-        writeln!(w, "    fn validate(&self) -> Result<(), String> {{")?;
+        writeln!(w, "    fn validate(&self) -> ::std::result::Result<(), ::std::string::String> {{")?;
         for (member_name, member) in &self.members {
             let rust_member_name = member_name.to_snake_case();
             let is_required = member.is_required();
@@ -281,7 +308,7 @@ impl Structure {
                 writeln!(w, "        if self.{rust_member_name}.is_none() {{")?;
                 writeln!(
                     w,
-                    "            return Err(\"Missing required field '{member_name}' when building {rust_typename}\".to_string());"
+                    "            return ::std::result::Result::Err(\"Missing required field '{member_name}' when building {rust_typename}\".to_string());"
                 )?;
                 writeln!(w, "        }}")?;
             }
@@ -305,11 +332,51 @@ impl Structure {
                 }
             }
         }
-        writeln!(w, "        Ok(())")?;
+        writeln!(w, "        ::std::result::Result::Ok(())")?;
+        writeln!(w, "    }}")?;
+        writeln!(w)?;
+
+        // 4. The public build() method. validate() catches missing-required and per-field
+        //    constraint failures, so required fields can be unwrapped safely once it returns Ok.
+        writeln!(w, "    /// Consumes the builder and constructs a [`{rust_typename}`].")?;
+        writeln!(
+            w,
+            "    pub fn build(self) -> ::std::result::Result<{rust_typename}, crate::types::error::ValidationError> {{"
+        )?;
+        writeln!(
+            w,
+            "        self.validate().map_err(|msg| crate::types::error::ValidationError::builder().message(msg).build())?;"
+        )?;
+        writeln!(w, "        ::std::result::Result::Ok({rust_typename} {{")?;
+        for (member_name, member) in &self.members {
+            let rust_member_name = member_name.to_snake_case();
+            let is_required = member.is_required();
+            let is_list = member.is_list();
+            if is_required && !is_list {
+                writeln!(
+                    w,
+                    "            {rust_member_name}: self.{rust_member_name}.expect(\"validate confirmed required field is set\"),"
+                )?;
+            } else {
+                writeln!(w, "            {rust_member_name}: self.{rust_member_name}.unwrap_or_default(),")?;
+            }
+        }
+        writeln!(w, "        }})")?;
         writeln!(w, "    }}")?;
         writeln!(w, "}}")?;
         writeln!(w)?;
         Ok(())
+    }
+
+    /// Returns the struct's field Rust type for a member (matching `write_rust_decl`).
+    fn builder_field_type(&self, member: &Member) -> String {
+        let is_optional = !member.traits.is_required();
+        let is_list = member.is_list();
+        let mut t = member.rust_typename();
+        if is_optional && !is_list {
+            t = format!("::std::option::Option<{t}>");
+        }
+        t
     }
 
     /// Writes a builder structure for this error type instead of using derive_builder.


### PR DESCRIPTION
derive_builder was returning a custom error type for each struct, while we need ValidationError to be generated instead. This removes the use of derive_builder and generates the builder code manually.